### PR TITLE
Fix HDMI receive frame acknowledge timing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ This is currently working with:
 * through a Denon AVR connected to the Sharp TV (physical address 0x1100)
    * Pico-CEC connected to Denon AVR HDMI input 1
    * Denon AVR connected to TV HDMI input 1
+* a Sony 60" TV (physical address 0x1000)
+   * directly connected to TV HDMI input 1
 
 # Design
 ## Hardware


### PR DESCRIPTION
During the ACK bit, pull the line to low impedance at the start. The HDMI v1.3a specification requires low impedance from the follower no later than T1 == 0.35ms after start of bit.

Reduce the idle time before frame transmission to 7 bit times.

Whilst here, add additional responses:
* broadcast physical address
* broadcast device vendor ID
* on routing change, broadcast image view on