### PR TITLE
Fix support for Samsung TV.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/FreeRTOS-Kernel/portable/ThirdParty
 # Initialize the SDK
 pico_sdk_init()
 
+add_compile_options(-Wall -Werror)
+
 add_executable(${PROJECT}
   src/freertos_hook.c
   src/hdmi-cec.c
@@ -32,18 +34,16 @@ add_executable(${PROJECT}
   src/usb_hid.c)
 
 target_include_directories(${PROJECT} PRIVATE
-  ${PROJECT_SOURCE_DIR}/include)
+  ${PROJECT_SOURCE_DIR}/include
+  ${PROJECT_SOURCE_DIR}/include/tusb)
 
 set(CEC_PIN "3" CACHE STRING "GPIO pin for HDMI CEC.")
 
 set_source_files_properties(src/hdmi-cec.c PROPERTIES COMPILE_DEFINITIONS
   "CEC_PIN=${CEC_PIN}")
 
-target_compile_options(${PROJECT} PRIVATE
-  -Wall -Werror)
-
 # Undefine TinyUSB built-in OS, redefined in our tusb_config.h
-target_compile_options(tinyusb_common_base INTERFACE
+target_compile_options(${PROJECT} PRIVATE
   -UCFG_TUSB_OS)
 
 target_link_libraries(${PROJECT}
@@ -60,3 +60,5 @@ pico_set_binary_type(${PROJECT} copy_to_ram)
 # disable stdio and uart
 pico_enable_stdio_usb(${PROJECT} 0)
 pico_enable_stdio_uart(${PROJECT} 0)
+
+include(debug.cmake)

--- a/debug.cmake
+++ b/debug.cmake
@@ -1,0 +1,22 @@
+# debug output, no USB, just prints to serial
+set(PROJECT_DEBUG ${PROJECT}-debug)
+add_executable(${PROJECT_DEBUG}
+  src/freertos_hook.c
+  src/hdmi-cec.c
+  src/hdmi-ddc.c
+  src/debug.c)
+
+target_include_directories(${PROJECT_DEBUG} PRIVATE
+  ${PROJECT_SOURCE_DIR}/include)
+
+target_link_libraries(${PROJECT_DEBUG}
+  pico_stdlib
+  pico_unique_id
+  hardware_i2c
+  FreeRTOS-Kernel)
+
+pico_add_extra_outputs(${PROJECT_DEBUG})
+pico_set_binary_type(${PROJECT_DEBUG} copy_to_ram)
+
+# enable stdio
+pico_enable_stdio_usb(${PROJECT_DEBUG} 1)

--- a/include/FreeRTOSConfig.h
+++ b/include/FreeRTOSConfig.h
@@ -136,64 +136,9 @@
 #define configASSERT(x) (void)(x)
 #endif
 
-#ifdef __RX__
-/* Renesas RX series */
-#define vSoftwareInterruptISR INT_Excep_ICU_SWINT
-#define vTickISR INT_Excep_CMT0_CMI0
-#define configPERIPHERAL_CLOCK_HZ (configCPU_CLOCK_HZ / 2)
-#define configKERNEL_INTERRUPT_PRIORITY 1
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY 4
-
-#else
-
 /* FreeRTOS hooks to NVIC vectors */
 #define xPortPendSVHandler PendSV_Handler
 #define xPortSysTickHandler SysTick_Handler
 #define vPortSVCHandler SVC_Handler
-
-#if 0
-//--------------------------------------------------------------------+
-// Interrupt nesting behavior configuration.
-//--------------------------------------------------------------------+
-#if defined(__NVIC_PRIO_BITS)
-  // For Cortex-M specific: __NVIC_PRIO_BITS is defined in core_cmx.h
-#define configPRIO_BITS __NVIC_PRIO_BITS
-
-#elif defined(__ECLIC_INTCTLBITS)
-  // RISC-V Bumblebee core from nuclei
-#define configPRIO_BITS __ECLIC_INTCTLBITS
-
-#elif defined(__IASMARM__)
-  // FIXME: IAR Assembler cannot include mcu header directly to get __NVIC_PRIO_BITS.
-  // Therefore we will hard coded it to minimum value of 2 to get pass ci build.
-  // IAR user must update this to correct value of the target MCU
-#message "configPRIO_BITS is hard coded to 2 to pass IAR build only. User should update it per MCU"
-#define configPRIO_BITS 2
-
-#else
-#error "FreeRTOS configPRIO_BITS to be defined"
-#endif
-
-/* The lowest interrupt priority that can be used in a call to a "set priority" function. */
-#define configLIBRARY_LOWEST_INTERRUPT_PRIORITY ((1 << configPRIO_BITS) - 1)
-
-/* The highest interrupt priority that can be used by any interrupt service
-routine that makes calls to interrupt safe FreeRTOS API functions.  DO NOT CALL
-INTERRUPT SAFE FREERTOS API FUNCTIONS FROM ANY INTERRUPT THAT HAS A HIGHER
-PRIORITY THAN THIS! (higher priorities are lower numeric values. */
-#define configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY 2
-
-/* Interrupt priorities used by the kernel port layer itself.  These are generic
-to all Cortex-M ports, and do not rely on any particular library functions. */
-#define configKERNEL_INTERRUPT_PRIORITY \
-  (configLIBRARY_LOWEST_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
-
-/* !!!! configMAX_SYSCALL_INTERRUPT_PRIORITY must not be set to zero !!!!
-See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
-#define configMAX_SYSCALL_INTERRUPT_PRIORITY \
-  (configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY << (8 - configPRIO_BITS))
-#endif
-
-#endif
 
 #endif /* __FREERTOS_CONFIG__H */

--- a/include/tusb/tusb_config.h
+++ b/include/tusb/tusb_config.h
@@ -53,7 +53,7 @@ extern "C" {
 #error CFG_TUSB_MCU must be defined
 #endif
 
-// This examples use FreeRTOS
+// Use FreeRTOS
 #define CFG_TUSB_OS OPT_OS_FREERTOS
 
 // Espressif IDF requires "freertos/" prefix in include path

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+
+#include "FreeRTOS.h"
+#include "queue.h"
+#include "task.h"
+
+#include "hardware/timer.h"
+#include "pico/stdlib.h"
+
+#include "hdmi-cec.h"
+
+#define BLINK_STACK_SIZE (128)
+#define CEC_STACK_SIZE (512)
+#define CEC_QUEUE_LENGTH (16)
+
+void blink_task(void *param) {
+  static uint32_t blink_delay = 1000;
+  static bool state = true;
+
+  while (true) {
+    gpio_put(PICO_DEFAULT_LED_PIN, state);
+    state = !state;
+    vTaskDelay(pdMS_TO_TICKS(blink_delay));
+  }
+}
+
+int main() {
+  static StaticQueue_t xStaticCECQueue;
+  static uint8_t storageCECQueue[CEC_QUEUE_LENGTH * sizeof(uint8_t)];
+
+  static StackType_t stackBlink[BLINK_STACK_SIZE];
+  static StackType_t stackCEC[CEC_STACK_SIZE];
+
+  static StaticTask_t xBlinkTCB;
+  static StaticTask_t xCECTCB;
+
+  static TaskHandle_t xBlinkTask;
+
+  stdio_init_all();
+
+  alarm_pool_init_default();
+
+  gpio_init(PICO_DEFAULT_LED_PIN);
+  gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);
+
+  // HID key queue
+  QueueHandle_t cec_q =
+      xQueueCreateStatic(CEC_QUEUE_LENGTH, sizeof(uint8_t), &storageCECQueue[0], &xStaticCECQueue);
+
+  xBlinkTask = xTaskCreateStatic(blink_task, "Blink Task", BLINK_STACK_SIZE, NULL, 1,
+                                 &stackBlink[0], &xBlinkTCB);
+  xCECTask = xTaskCreateStatic(cec_task, CEC_TASK_NAME, CEC_STACK_SIZE, &cec_q,
+                               configMAX_PRIORITIES - 1, &stackCEC[0], &xCECTCB);
+
+  // bind CEC, blink and HID to core 0
+  vTaskCoreAffinitySet(xCECTask, (1 << 0));
+  vTaskCoreAffinitySet(xBlinkTask, (1 << 0));
+
+  vTaskStartScheduler();
+
+  return 0;
+}

--- a/src/hdmi-cec.c
+++ b/src/hdmi-cec.c
@@ -54,6 +54,69 @@ const command_t keymap[256] = {[0x00] = {"User Control Select", HID_KEY_ENTER},
                                [0x48] = {"User Control Rewind", HID_KEY_R},
                                [0x49] = {"User Control Fast Forward", HID_KEY_F}};
 
+typedef enum {
+  CEC_ID_IMAGE_VIEW_ON = 0x04,
+  CEC_ID_TEXT_VIEW_ON = 0x0d,
+  CEC_ID_STANDBY = 0x36,
+  CEC_ID_USER_CONTROL_PRESSED = 0x44,
+  CEC_ID_USER_CONTROL_RELEASED = 0x45,
+  CEC_ID_GIVE_OSD_NAME = 0x46,
+  CEC_ID_SET_OSD_NAME = 0x47,
+  CEC_ID_SYSTEM_AUDIO_MODE_REQUEST = 0x70,
+  CEC_ID_GIVE_AUDIO_STATUS = 0x71,
+  CEC_ID_SET_SYSTEM_AUDIO_MODE = 0x72,
+  CEC_ID_GIVE_SYSTEM_AUDIO_MODE_STATUS = 0x7d,
+  CEC_ID_SYSTEM_AUDIO_MODE_STATUS = 0x7e,
+  CEC_ID_REPORT_AUDIO_STATUS = 0x7a,
+  CEC_ID_ROUTING_CHANGE = 0x80,
+  CEC_ID_ACTIVE_SOURCE = 0x82,
+  CEC_ID_GIVE_PHYSICAL_ADDRESS = 0x83,
+  CEC_ID_REPORT_PHYSICAL_ADDRESS = 0x84,
+  CEC_ID_REQUEST_ACTIVE_SOURCE = 0x85,
+  CEC_ID_SET_STREAM_PATH = 0x86,
+  CEC_ID_DEVICE_VENDOR_ID = 0x87,
+  CEC_ID_GIVE_DEVICE_VENDOR_ID = 0x8c,
+  CEC_ID_MENU_STATUS = 0x8e,
+  CEC_ID_GIVE_DEVICE_POWER_STATUS = 0x8f,
+  CEC_ID_REPORT_POWER_STATUS = 0x90,
+  CEC_ID_GET_MENU_LANGUAGE = 0x81,
+  CEC_ID_INACTIVE_SOURCE = 0x9d,
+  CEC_ID_CEC_VERSION = 0x9e,
+  CEC_ID_GET_CEC_VERSION = 0x9f,
+  CEC_ID_VENDOR_COMMAND_WITH_ID = 0xa0,
+  CEC_ID_ABORT = 0xff,
+} cec_id_t;
+
+const char *cec_message[] = {
+    [CEC_ID_IMAGE_VIEW_ON] = "Image View On",
+    [CEC_ID_TEXT_VIEW_ON] = "Text View On",
+    [CEC_ID_STANDBY] = "Standby",
+    [CEC_ID_USER_CONTROL_PRESSED] = "User Control Pressed",
+    [CEC_ID_USER_CONTROL_RELEASED] = "User Control Released",
+    [CEC_ID_SET_OSD_NAME] = "Set OSD Name",
+    [CEC_ID_SYSTEM_AUDIO_MODE_REQUEST] = "System Audio Mode Request",
+    [CEC_ID_GIVE_AUDIO_STATUS] = "Give Audio Status",
+    [CEC_ID_SET_SYSTEM_AUDIO_MODE] = "Set System Audio Mode",
+    [CEC_ID_GIVE_SYSTEM_AUDIO_MODE_STATUS] = "Give System Audio Mode",
+    [CEC_ID_SYSTEM_AUDIO_MODE_STATUS] = "System Audio Mode Status",
+    [CEC_ID_ROUTING_CHANGE] = "Routing Change",
+    [CEC_ID_ACTIVE_SOURCE] = "Active Source",
+    [CEC_ID_GIVE_PHYSICAL_ADDRESS] = "Give Physical Address",
+    [CEC_ID_REPORT_PHYSICAL_ADDRESS] = "Report Physical Address",
+    [CEC_ID_REQUEST_ACTIVE_SOURCE] = "Request Active Source",
+    [CEC_ID_SET_STREAM_PATH] = "Set Stream Path",
+    [CEC_ID_DEVICE_VENDOR_ID] = "Device Vendor ID",
+    [CEC_ID_GIVE_DEVICE_VENDOR_ID] = "Give Device Vendor ID",
+    [CEC_ID_MENU_STATUS] = "Menu Status",
+    [CEC_ID_GIVE_DEVICE_POWER_STATUS] = "Give Device Power Status",
+    [CEC_ID_REPORT_POWER_STATUS] = "Report Power Status",
+    [CEC_ID_GET_MENU_LANGUAGE] = "Get Menu Language",
+    [CEC_ID_CEC_VERSION] = "CEC Version",
+    [CEC_ID_GET_CEC_VERSION] = "Get CEC Version",
+    [CEC_ID_VENDOR_COMMAND_WITH_ID] = "Vendor Command With ID",
+    [CEC_ID_ABORT] = "Abort",
+};
+
 #define DEFAULT_TYPE 0x04  // HDMI Playback 1
 
 // HDMI Playback logical addresses
@@ -327,14 +390,14 @@ static void device_vendor_id(uint8_t initiator, uint8_t destination, uint32_t ve
                     (vendor_id >> 8) & 0x0ff, (vendor_id >> 0) & 0x0ff};
 
   send_frame(5, pld);
-  printf("\n<-- %02x:87 [Device Vendor ID]", pld[0]);
+  printf("\n<-- %02x:%02x [%s]", pld[0], pld[1], cec_message[CEC_ID_DEVICE_VENDOR_ID]);
 }
 
 static void report_power_status(uint8_t initiator, uint8_t destination, uint8_t power_status) {
   uint8_t pld[3] = {(initiator << 4) | destination, 0x90, power_status};
 
   send_frame(3, pld);
-  printf("\n<-- %02x:90 [Report Power Status]", pld[0]);
+  printf("\n<-- %02x:%02x [%s]", pld[0], pld[1], cec_message[CEC_ID_REPORT_POWER_STATUS]);
 }
 
 static void set_system_audio_mode(uint8_t initiator,
@@ -343,22 +406,22 @@ static void set_system_audio_mode(uint8_t initiator,
   uint8_t pld[3];
 
   pld[0] = (initiator << 4) | destination;
-  pld[1] = 0x72;
+  pld[1] = CEC_ID_SET_SYSTEM_AUDIO_MODE;
   pld[2] = system_audio_mode;
 
   send_frame(3, pld);
-  printf("\n<-- %02x:72 [Set System Audio Mode]", pld[0]);
+  printf("\n<-- %02x:%02x [%s]", pld[0], pld[1], cec_message[CEC_ID_SET_SYSTEM_AUDIO_MODE]);
 }
 
 static void report_audio_status(uint8_t initiator, uint8_t destination, uint8_t audio_status) {
   uint8_t pld[3];
 
   pld[0] = (initiator << 4) | destination;
-  pld[1] = 0x7a;
+  pld[1] = CEC_ID_REPORT_AUDIO_STATUS;
   pld[2] = audio_status;
 
   send_frame(3, pld);
-  printf("\n<-- %02x:7a [Report Audio Status]", pld[0]);
+  printf("\n<-- %02x:%02x [%s]", pld[0], pld[1], cec_message[CEC_ID_REPORT_AUDIO_STATUS]);
 }
 
 static void system_audio_mode_status(uint8_t initiator,
@@ -367,36 +430,38 @@ static void system_audio_mode_status(uint8_t initiator,
   uint8_t pld[3];
 
   pld[0] = (initiator << 4) | destination;
-  pld[1] = 0x7e;
+  pld[1] = CEC_ID_SYSTEM_AUDIO_MODE_STATUS;
   pld[2] = system_audio_mode_status;
 
   send_frame(3, pld);
-  printf("\n<-- %02x:7e [System Audio Mode Status]", pld[0]);
+  printf("\n<-- %02x:%02x [%s]", pld[0], pld[1], cec_message[CEC_ID_SYSTEM_AUDIO_MODE_STATUS]);
 }
 
 static void set_osd_name(uint8_t initiator, uint8_t destination) {
-  uint8_t pld[10] = {(initiator << 4) | destination, 0x47, 'P', 'i', 'c', 'o', '-', 'C', 'E', 'C'};
+  uint8_t pld[10] = {
+      (initiator << 4) | destination, CEC_ID_SET_OSD_NAME, 'P', 'i', 'c', 'o', '-', 'C', 'E', 'C'};
 
   send_frame(10, pld);
-  printf("\n<-- %02x:47 [Set OSD Name]", pld[0]);
+  printf("\n<-- %02x:%02x [%s]", pld[0], pld[1], cec_message[CEC_ID_SET_OSD_NAME]);
 }
 
 static void report_physical_address(uint8_t initiator,
                                     uint8_t destination,
                                     uint16_t physical_address,
                                     uint8_t device_type) {
-  uint8_t pld[5] = {(initiator << 4) | destination, 0x84, (physical_address >> 8) & 0x0ff,
-                    (physical_address >> 0) & 0x0ff, device_type};
+  uint8_t pld[5] = {(initiator << 4) | destination, CEC_ID_REPORT_PHYSICAL_ADDRESS,
+                    (physical_address >> 8) & 0x0ff, (physical_address >> 0) & 0x0ff, device_type};
 
   send_frame(5, pld);
-  printf("\n<-- %02x:84 [Report Physical Address] %02x%02x", pld[0], pld[2], pld[3]);
+  printf("\n<-- %02x:%02x [%s] %02x%02x", pld[0], pld[1],
+         cec_message[CEC_ID_REPORT_PHYSICAL_ADDRESS], pld[2], pld[3]);
 }
 
 static void report_cec_version(uint8_t initiator, uint8_t destination) {
   // 0x04 = 1.3a
-  uint8_t pld[3] = {HEADER0(initiator, destination), 0x9e, 0x04};
+  uint8_t pld[3] = {HEADER0(initiator, destination), CEC_ID_CEC_VERSION, 0x04};
   send_frame(3, pld);
-  printf("\n<-- %02x:9e [CEC Version]", pld[0]);
+  printf("\n<-- %02x:%02x [%s]", pld[0], pld[1], cec_message[CEC_ID_CEC_VERSION]);
 }
 
 static bool ping(uint8_t destination) {
@@ -406,18 +471,18 @@ static bool ping(uint8_t destination) {
 }
 
 static void image_view_on(uint8_t initiator, uint8_t destination) {
-  uint8_t pld[2] = {HEADER0(initiator, destination), 0x04};
+  uint8_t pld[2] = {HEADER0(initiator, destination), CEC_ID_IMAGE_VIEW_ON};
 
   send_frame(2, pld);
-  printf("\n<-- %02x:04 [Image View On]", pld[0]);
+  printf("\n<-- %02x:%02x [%s]", pld[0], pld[1], cec_message[CEC_ID_IMAGE_VIEW_ON]);
 }
 
 static void active_source(uint8_t initiator, uint16_t physical_address) {
-  uint8_t pld[4] = {HEADER0(initiator, 0x0f), 0x82, (physical_address >> 8) & 0x0ff,
+  uint8_t pld[4] = {HEADER0(initiator, 0x0f), CEC_ID_ACTIVE_SOURCE, (physical_address >> 8) & 0x0ff,
                     (physical_address >> 0) & 0x0ff};
 
   send_frame(4, pld);
-  printf("\n<-- %02x:%02x [%s]", pld[0], pld[1], "Active Source");
+  printf("\n<-- %02x:%02x [%s]", pld[0], pld[1], cec_message[CEC_ID_ACTIVE_SOURCE]);
 }
 
 static uint8_t allocate_logical_address(void) {
@@ -462,55 +527,40 @@ void cec_task(void *data) {
     printf("%02x -> %02x: ", initiator, destination);
 
     if ((pldcnt > 1)) {
+      printf("[%s]", cec_message[pld[1]]);
       switch (pld[1]) {
-        case 0x04:
-          printf("[Image View On]");
+        case CEC_ID_IMAGE_VIEW_ON:
           break;
-        case 0x0d:
-          printf("[Text View On]");
+        case CEC_ID_TEXT_VIEW_ON:
           break;
-        case 0x36:
-          printf("[Standby]");
+        case CEC_ID_STANDBY:
           printf("<*> [Turn the display OFF]");
           break;
-        case 0x70:
-          printf("[System Audio Mode Request]");
+        case CEC_ID_SYSTEM_AUDIO_MODE_REQUEST:
           if (destination == laddr)
             set_system_audio_mode(laddr, 0x0f, 1);
           break;
-        case 0x71:
-          printf("[Give Audio Status]");
+        case CEC_ID_GIVE_AUDIO_STATUS:
           if (destination == laddr)
             report_audio_status(laddr, initiator, 0x32);  // volume 50%, mute off
           break;
-        case 0x72:
-          printf("[Set System Audio Mode]");
+        case CEC_ID_SET_SYSTEM_AUDIO_MODE:
           break;
-        case 0x7d:
-          printf("[Give System Audio Mode Status]");
+        case CEC_ID_GIVE_SYSTEM_AUDIO_MODE_STATUS:
           if (destination == laddr)
             system_audio_mode_status(laddr, initiator, 1);
           break;
-        case 0x7e:
-          printf("[System Audio Mode Status]");
+        case CEC_ID_SYSTEM_AUDIO_MODE_STATUS:
           break;
-        case 0x80:
-          printf("[Routing Change]");
+        case CEC_ID_ROUTING_CHANGE:
           paddr = ddc_get_physical_address();
           image_view_on(laddr, 0x00);
           break;
-        case 0x82:
-          printf("[Active Source]\n");
+        case CEC_ID_ACTIVE_SOURCE:
           printf("<*> [Turn the display ON]");
           break;
-        case 0x86:
-          printf("[Set Stream Path]");
-          if (paddr != 0x0000) {
-            active_source(laddr, paddr);
-          }
-          break;
-        case 0x84:
-          printf("[Report Physical Address>] %02x%02x", pld[2], pld[3]);
+        case CEC_ID_REPORT_PHYSICAL_ADDRESS:
+          printf("  %02x%02x", pld[2], pld[3]);
           // On broadcast receive, do the same
           if ((initiator == 0x00) && (destination == 0x0f)) {
             paddr = ddc_get_physical_address();
@@ -520,64 +570,56 @@ void cec_task(void *data) {
             }
           }
           break;
-        case 0x85:
-          printf("[Request Active Source]");
+        case CEC_ID_REQUEST_ACTIVE_SOURCE:
           break;
-        case 0x87:
-          printf("[Device Vendor ID]");
+        case CEC_ID_SET_STREAM_PATH:
+          if (paddr != 0x0000) {
+            active_source(laddr, paddr);
+          }
+          break;
+        case CEC_ID_DEVICE_VENDOR_ID:
           // On broadcast receive, do the same
           if ((initiator == 0x00) && (destination == 0x0f)) {
             device_vendor_id(laddr, 0x0f, 0x0010FA);
           }
           break;
-        case 0x8c:
-          printf("[Give Device Vendor ID]");
+        case CEC_ID_GIVE_DEVICE_VENDOR_ID:
           if (destination == laddr)
             device_vendor_id(laddr, 0x0f, 0x0010FA);
           break;
-        case 0x8e:
-          printf("[Menu Status]");
+        case CEC_ID_MENU_STATUS:
           break;
-        case 0x8f:
-          printf("[Give Device Power Status]");
+        case CEC_ID_GIVE_DEVICE_POWER_STATUS:
           if (destination == laddr)
             report_power_status(laddr, initiator, 0x00);
           /* Hack for Google Chromecast to force it sending V+/V- if no CEC TV is present */
           if (destination == 0)
             report_power_status(0, initiator, 0x00);
           break;
-        case 0x90:
-          printf("[Report Power Status]");
+        case CEC_ID_REPORT_POWER_STATUS:
           break;
-        case 0x91:
-          printf("[Get Menu Language]");
+        case CEC_ID_GET_MENU_LANGUAGE:
           break;
-        case 0x9d:
-          printf("[Inactive Source]");
+        case CEC_ID_INACTIVE_SOURCE:
           break;
-        case 0x9e:
-          printf("[CEC Version]");
+        case CEC_ID_CEC_VERSION:
           break;
-        case 0x9f:
-          printf("[Get CEC Version]");
+        case CEC_ID_GET_CEC_VERSION:
           if (destination == laddr) {
             report_cec_version(laddr, initiator);
           }
           break;
-        case 0x46:
-          printf("[Give OSD Name]");
+        case CEC_ID_GIVE_OSD_NAME:
           if (destination == laddr)
             set_osd_name(laddr, initiator);
           break;
-        case 0x47:
-          printf("[Set OSD Name]");
+        case CEC_ID_SET_OSD_NAME:
           break;
-        case 0x83:
-          printf("[Give Physical Address]");
+        case CEC_ID_GIVE_PHYSICAL_ADDRESS:
           if (destination == laddr && paddr != 0x0000)
             report_physical_address(laddr, 0x0f, paddr, DEFAULT_TYPE);
           break;
-        case 0x44:
+        case CEC_ID_USER_CONTROL_PRESSED:
           gpio_put(PICO_DEFAULT_LED_PIN, true);
           switch (pld[2]) {
             case 0x41:
@@ -597,16 +639,15 @@ void cec_task(void *data) {
             }
           }
           break;
-        case 0x45:
+        case CEC_ID_USER_CONTROL_RELEASED:
           gpio_put(PICO_DEFAULT_LED_PIN, false);
-          printf("[User Control Released]");
           key = HID_KEY_NONE;
           xQueueSend(*q, &key, pdMS_TO_TICKS(10));
           break;
-        case 0xFF:
+        case CEC_ID_ABORT:
           printf("[Abort]");
           break;
-        case 0xA0:
+        case CEC_ID_VENDOR_COMMAND_WITH_ID:
           printf("[Vendor Command with ID]");
           for (int i = 0; i < pldcnt; i++) {
             printf(" %02x", pld[i]);

--- a/src/hdmi-cec.c
+++ b/src/hdmi-cec.c
@@ -412,6 +412,14 @@ static void image_view_on(uint8_t initiator, uint8_t destination) {
   printf("\n<-- %02x:04 [Image View On]", pld[0]);
 }
 
+static void active_source(uint8_t initiator, uint16_t physical_address) {
+  uint8_t pld[4] = {HEADER0(initiator, 0x0f), 0x82, (physical_address >> 8) & 0x0ff,
+                    (physical_address >> 0) & 0x0ff};
+
+  send_frame(4, pld);
+  printf("\n<-- %02x:%02x [%s]", pld[0], pld[1], "Active Source");
+}
+
 static uint8_t allocate_logical_address(void) {
   uint8_t a;
   for (unsigned int i = 0; i < NUM_ADDRESS; i++) {
@@ -494,6 +502,12 @@ void cec_task(void *data) {
         case 0x82:
           printf("[Active Source]\n");
           printf("<*> [Turn the display ON]");
+          break;
+        case 0x86:
+          printf("[Set Stream Path]");
+          if (paddr != 0x0000) {
+            active_source(laddr, paddr);
+          }
           break;
         case 0x84:
           printf("[Report Physical Address>] %02x%02x", pld[2], pld[3]);

--- a/src/hdmi-ddc.c
+++ b/src/hdmi-ddc.c
@@ -131,8 +131,20 @@ static uint16_t get_physical_address(void) {
 }
 
 uint16_t ddc_get_physical_address(void) {
+  uint8_t zero = 0x00;
+  uint16_t address = 0x0000;
+
   ddc_init();
-  uint16_t address = get_physical_address();
+
+  // issue a DDC reset
+  int ret = i2c_write_timeout_us(i2c_default, EDID_I2C_ADDR, &zero, 1, true, EDID_I2C_TIMEOUT_US);
+  if (ret != 1) {
+    printf("Failed to write DDC reset\n");
+    return 0x0000;
+  }
+
+  address = get_physical_address();
   ddc_exit();
+
   return address;
 }

--- a/src/hdmi-ddc.c
+++ b/src/hdmi-ddc.c
@@ -35,7 +35,7 @@ static int verify(uint8_t *edid, size_t len) {
   uint16_t cksum = 0x0000;
 
   for (size_t i = 0; i < len; i++) {
-    // printf("[%d] %02x\n", i, edid[i]);
+    printf("[%d] %02x\n", i, edid[i]);
     cksum += edid[i];
   }
 


### PR DESCRIPTION
Add EDID reset to ensure correct read offset.
Add correct 'Active Source' reply to 'Set Stream Path' message.
Refactor handling of CEC messages to be table based.
Add debug build output (pico-cec-debug) for getting a serial console output of CEC activity. (USB HID capability is disabled with this build).