### PR TITLE
Add small delay to start of HDMI CEC task.

### DIFF
--- a/src/hdmi-cec.c
+++ b/src/hdmi-cec.c
@@ -502,6 +502,9 @@ static uint8_t allocate_logical_address(void) {
 void cec_task(void *data) {
   QueueHandle_t *q = (QueueHandle_t *)data;
 
+  // pause 5000ms
+  vTaskDelay(pdMS_TO_TICKS(5000));
+
   gpio_init(CEC_PIN);
   gpio_disable_pulls(CEC_PIN);
   gpio_set_dir(CEC_PIN, GPIO_IN);


### PR DESCRIPTION
The DDC/EDID traffic seems to disrupt the PC BIOS from determining valid display outputs during boot.

This is likely due to pico-cec acting as another master on the I2C bus.

Delay our DDC activity by 5000ms to allow the PC BIOS to "do it's thing" first.