### PR TITLE
Initial support for USB composite device HID and CDC.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         clang-format-version: '13'
         check-path: .
-        exclude-regex: '(FreeRTOS-Kernel\/.+|pico-sdk\/.+)'
+        exclude-regex: '(FreeRTOS-Kernel\/.+|pico-sdk\/.+|tcli\/.+)'
 
   build:
     needs: format
@@ -46,7 +46,7 @@ jobs:
         sudo apt install -y gcc-arm-none-eabi openscad
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DPICO_CEC_VERSION=${github.ref_name}
 
     - name: Build Pico-CEC
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
         sudo apt install -y gcc-arm-none-eabi openscad
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DPICO_CEC_VERSION=${github.ref_name}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DPICO_CEC_VERSION=${{github.ref_name}}
 
     - name: Build Pico-CEC
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "pico-sdk"]
 	path = pico-sdk
 	url = https://github.com/raspberrypi/pico-sdk.git
+[submodule "tcli"]
+	path = tcli
+	url = https://github.com/dpse/tcli

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,7 @@ add_executable(${PROJECT}
 
 target_include_directories(${PROJECT} PRIVATE
   ${PROJECT_SOURCE_DIR}/include
-  ${PROJECT_SOURCE_DIR}/include/tusb
-  ${PROJECT_SOURCE_DIR}/include/external)
+  ${PROJECT_SOURCE_DIR}/include/tusb)
 
 set(CEC_PIN "3" CACHE STRING "GPIO pin for HDMI CEC.")
 set(PICO_CEC_VERSION "unknown" CACHE STRING "Pico-CEC version string.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,22 +25,45 @@ pico_sdk_init()
 
 add_compile_options(-Wall -Werror)
 
+set(TCLI_SOURCE_DIR ${PROJECT_SOURCE_DIR}/tcli)
+
+add_library(tcli STATIC
+  ${TCLI_SOURCE_DIR}/source/tcli.c
+  ${TCLI_SOURCE_DIR}/source/tclie.c)
+
+target_include_directories(tcli PUBLIC
+  ${TCLI_SOURCE_DIR}/include)
+
+target_compile_definitions(tcli PUBLIC
+  TCLI_COMPLETE=1
+  TCLIE_ENABLE_USERS=0
+  TCLIE_PATTERN_MATCH=1)
+
+target_compile_options(tcli PRIVATE
+  -Wno-stringop-truncation)
+
 add_executable(${PROJECT}
   src/freertos_hook.c
   src/hdmi-cec.c
   src/hdmi-ddc.c
   src/main.c
+  src/usb_cdc.c
   src/usb_descriptors.c
   src/usb_hid.c)
 
 target_include_directories(${PROJECT} PRIVATE
   ${PROJECT_SOURCE_DIR}/include
-  ${PROJECT_SOURCE_DIR}/include/tusb)
+  ${PROJECT_SOURCE_DIR}/include/tusb
+  ${PROJECT_SOURCE_DIR}/include/external)
 
 set(CEC_PIN "3" CACHE STRING "GPIO pin for HDMI CEC.")
+set(PICO_CEC_VERSION "unknown" CACHE STRING "Pico-CEC version string.")
 
 set_source_files_properties(src/hdmi-cec.c PROPERTIES COMPILE_DEFINITIONS
   "CEC_PIN=${CEC_PIN}")
+
+set_source_files_properties(src/usb_cdc.c PROPERTIES COMPILE_DEFINITIONS
+  "PICO_CEC_VERSION=\"${PICO_CEC_VERSION}\"")
 
 # Undefine TinyUSB built-in OS, redefined in our tusb_config.h
 target_compile_options(${PROJECT} PRIVATE
@@ -52,7 +75,8 @@ target_link_libraries(${PROJECT}
   hardware_i2c
   tinyusb_device
   tinyusb_board
-  FreeRTOS-Kernel)
+  FreeRTOS-Kernel
+  tcli)
 
 pico_add_extra_outputs(${PROJECT})
 pico_set_binary_type(${PROJECT} copy_to_ram)

--- a/include/tusb/tusb_config.h
+++ b/include/tusb/tusb_config.h
@@ -97,13 +97,17 @@ extern "C" {
 
 //------------- CLASS -------------//
 #define CFG_TUD_HID 1
-#define CFG_TUD_CDC 0
+#define CFG_TUD_CDC 1
 #define CFG_TUD_MSC 0
 #define CFG_TUD_MIDI 0
 #define CFG_TUD_VENDOR 0
 
 // HID buffer size Should be sufficient to hold ID (if any) + Data
 #define CFG_TUD_HID_EP_BUFSIZE 16
+
+// CDC buffer sizes
+#define CFG_TUD_CDC_RX_BUFSIZE (256)
+#define CFG_TUD_CDC_TX_BUFSIZE (256)
 
 #ifdef __cplusplus
 }

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 
 #define USBD_STACK_SIZE (512)
 #define HID_STACK_SIZE (256)
+#define CDC_STACK_SIZE (768)
 #define BLINK_STACK_SIZE (128)
 #define CEC_STACK_SIZE (512)
 #define CEC_QUEUE_LENGTH (16)
@@ -28,6 +29,8 @@ void blink_task(void *param) {
   }
 }
 
+void cdc_task(void *param);
+
 int main() {
   static StaticQueue_t xStaticCECQueue;
   static uint8_t storageCECQueue[CEC_QUEUE_LENGTH * sizeof(uint8_t)];
@@ -35,16 +38,19 @@ int main() {
   static StackType_t stackBlink[BLINK_STACK_SIZE];
   static StackType_t stackCEC[CEC_STACK_SIZE];
   static StackType_t stackHID[HID_STACK_SIZE];
+  static StackType_t stackCDC[CDC_STACK_SIZE];
   static StackType_t stackUSBD[USBD_STACK_SIZE];
 
   static StaticTask_t xBlinkTCB;
   static StaticTask_t xCECTCB;
   static StaticTask_t xHIDTCB;
+  static StaticTask_t xCDCTCB;
   static StaticTask_t xUSBDTCB;
 
   static TaskHandle_t xBlinkTask;
   static TaskHandle_t xUSBDTask;
   static TaskHandle_t xHIDTask;
+  static TaskHandle_t xCDCTask;
 
   stdio_init_all();
   board_init();
@@ -64,6 +70,8 @@ int main() {
                                configMAX_PRIORITIES - 1, &stackCEC[0], &xCECTCB);
   xHIDTask = xTaskCreateStatic(hid_task, "hid", HID_STACK_SIZE, &cec_q, configMAX_PRIORITIES - 2,
                                &stackHID[0], &xHIDTCB);
+  xCDCTask = xTaskCreateStatic(cdc_task, "cdc", CDC_STACK_SIZE, NULL, configMAX_PRIORITIES - 2,
+                               &stackCDC[0], &xCDCTCB);
   xUSBDTask = xTaskCreateStatic(usb_device_task, "usbd", USBD_STACK_SIZE, NULL,
                                 configMAX_PRIORITIES - 3, &stackUSBD[0], &xUSBDTCB);
 
@@ -71,6 +79,7 @@ int main() {
   vTaskCoreAffinitySet(xCECTask, (1 << 0));
   vTaskCoreAffinitySet(xBlinkTask, (1 << 0));
   vTaskCoreAffinitySet(xHIDTask, (1 << 0));
+  vTaskCoreAffinitySet(xCDCTask, (1 << 0));
 
   // bind USBD to core 1
   vTaskCoreAffinitySet(xUSBDTask, (1 << 1));

--- a/src/main.c
+++ b/src/main.c
@@ -44,8 +44,8 @@ int main() {
   static StaticTask_t xBlinkTCB;
   static StaticTask_t xCECTCB;
   static StaticTask_t xHIDTCB;
-  static StaticTask_t xCDCTCB;
   static StaticTask_t xUSBDTCB;
+  static StaticTask_t xCDCTCB;
 
   static TaskHandle_t xBlinkTask;
   static TaskHandle_t xUSBDTask;
@@ -70,12 +70,12 @@ int main() {
                                configMAX_PRIORITIES - 1, &stackCEC[0], &xCECTCB);
   xHIDTask = xTaskCreateStatic(hid_task, "hid", HID_STACK_SIZE, &cec_q, configMAX_PRIORITIES - 2,
                                &stackHID[0], &xHIDTCB);
-  xCDCTask = xTaskCreateStatic(cdc_task, "cdc", CDC_STACK_SIZE, NULL, configMAX_PRIORITIES - 2,
-                               &stackCDC[0], &xCDCTCB);
   xUSBDTask = xTaskCreateStatic(usb_device_task, "usbd", USBD_STACK_SIZE, NULL,
                                 configMAX_PRIORITIES - 3, &stackUSBD[0], &xUSBDTCB);
+  xCDCTask = xTaskCreateStatic(cdc_task, "cdc", CDC_STACK_SIZE, NULL, configMAX_PRIORITIES - 4,
+                               &stackCDC[0], &xCDCTCB);
 
-  // bind CEC, blink and HID to core 0
+  // bind CEC, blink, HID and CDC to core 0
   vTaskCoreAffinitySet(xCECTask, (1 << 0));
   vTaskCoreAffinitySet(xBlinkTask, (1 << 0));
   vTaskCoreAffinitySet(xHIDTask, (1 << 0));

--- a/src/usb_cdc.c
+++ b/src/usb_cdc.c
@@ -1,0 +1,76 @@
+#include <hardware/watchdog.h>
+#include <pico/bootrom.h>
+#include <tusb.h>
+
+#include "tclie.h"
+
+#ifndef PICO_CEC_VERSION
+#define PICO_CEC_VERSION "unknown"
+#endif
+
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+#define _ENDLINE_SEQ "\r\n"
+
+static void print(void *arg, const char *str) {
+  tud_cdc_write_str(str);
+}
+
+static int exec_reboot(void *arg, int argc, const char **argv) {
+  if ((argc == 2) && (strcmp(argv[1], "bootsel") == 0)) {
+    // reboot into USB bootloader
+    reset_usb_boot(PICO_DEFAULT_LED_PIN, 0);
+  } else {
+    // normal reboot
+    watchdog_reboot(0, 0, 0);
+  }
+
+  return -1;
+}
+
+static int exec_version(void *arg, int argc, const char **argv) {
+  print(arg, PICO_CEC_VERSION ""_ENDLINE_SEQ);
+  return 0;
+}
+
+static const tclie_cmd_t cmds[] = {
+    {"version", exec_version, "Display version.", "version"},
+    {"reboot", exec_reboot, "Reboot system.", "reboot [bootsel]"},
+};
+
+void cdc_task(void *params) {
+  (void)params;
+
+  tclie_t tclie;
+
+  tclie_init(&tclie, print, NULL);
+  tclie_reg_cmds(&tclie, cmds, ARRAY_SIZE(cmds));
+
+  while (1) {
+    // connected() check for DTR bit
+    // Most but not all terminal client set this when making connection
+    if (tud_cdc_connected()) {
+      // There are data available
+      while (tud_cdc_available()) {
+        uint8_t c = tud_cdc_read_char();
+        tclie_input_char(&tclie, c);
+      }
+
+      tud_cdc_write_flush();
+    }
+
+    vTaskDelay(1);
+  }
+}
+
+void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts) {
+  (void)itf;
+  (void)rts;
+
+  if (dtr) {
+    // Terminal connected
+    tud_cdc_write_str("Connected"_ENDLINE_SEQ);
+  } else {
+    // Terminal disconnected
+    tud_cdc_write_str("Disconnected"_ENDLINE_SEQ);
+  }
+}

--- a/src/usb_descriptors.c
+++ b/src/usb_descriptors.c
@@ -41,6 +41,16 @@
 #define USB_VID 0xCafe
 #define USB_BCD 0x0200
 
+/**
+ * CDC descriptor constants.
+ */
+#define USBD_STR_CDC (0x04)
+#define USBD_CDC_EP_CMD (0x81)
+#define USBD_CDC_CMD_MAX_SIZE (8)
+#define USBD_CDC_EP_OUT (0x02)
+#define USBD_CDC_EP_IN (0x82)
+#define USBD_CDC_IN_OUT_MAX_SIZE (64)
+
 //--------------------------------------------------------------------+
 // Device Descriptors
 //--------------------------------------------------------------------+
@@ -86,11 +96,11 @@ uint8_t const *tud_hid_descriptor_report_cb(uint8_t instance) {
 // Configuration Descriptor
 //--------------------------------------------------------------------+
 
-enum { ITF_NUM_HID, ITF_NUM_TOTAL };
+enum { ITF_NUM_HID, ITF_NUM_CDC, ITF_NUM_CDC_DATA, ITF_NUM_TOTAL };
 
-#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_HID_DESC_LEN)
+#define CONFIG_TOTAL_LEN (TUD_CONFIG_DESC_LEN + TUD_HID_DESC_LEN + TUD_CDC_DESC_LEN)
 
-#define EPNUM_HID 0x81
+#define EPNUM_HID 0x84
 
 uint8_t const desc_configuration[] = {
     // Config number, interface count, string index, total length, attribute, power in mA
@@ -109,7 +119,15 @@ uint8_t const desc_configuration[] = {
                        sizeof(desc_hid_report),
                        EPNUM_HID,
                        CFG_TUD_HID_EP_BUFSIZE,
-                       5)};
+                       5),
+
+    TUD_CDC_DESCRIPTOR(ITF_NUM_CDC,
+                       USBD_STR_CDC,
+                       USBD_CDC_EP_CMD,
+                       USBD_CDC_CMD_MAX_SIZE,
+                       USBD_CDC_EP_OUT,
+                       USBD_CDC_EP_IN,
+                       USBD_CDC_IN_OUT_MAX_SIZE)};
 
 #if TUD_OPT_HIGH_SPEED
 // Per USB specs: high speed capable device must report device_qualifier and
@@ -177,6 +195,7 @@ char const *string_desc_arr[] = {
     "TinyUSB",                   // 1: Manufacturer
     "TinyUSB Device",            // 2: Product
     "123456",                    // 3: Serials, should use chip ID
+    "Pico-CEC Console",          // 4: stdio
 };
 
 static uint16_t _desc_str[32];


### PR DESCRIPTION
Enable CDC so Pico-CEC appears as a connectable serial TTY device with baud rate 115200.
Add tcli v0.2.5 as submodule.

Add basic example CLI support via tcli for:
* reboot [bootsel]
   * "reboot" -> reboot system
   * "reboot bootsel" -> reboot into bootloader
* version
   * display version