### PR TITLE
Add 'Active Source' message handling and more.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install required packages
       shell: bash
       run: |
-        sudo apt install -y gcc-arm-none-eabi openscad
+        sudo apt install --no-install-recommends -y gcc-arm-none-eabi openscad
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DPICO_CEC_VERSION=${{github.ref_name}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install required packages
       shell: bash
       run: |
-        sudo apt install --no-install-recommends -y gcc-arm-none-eabi openscad
+        sudo apt install --no-install-recommends -y gcc-arm-none-eabi libnewlib-arm-none-eabi openscad
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DPICO_CEC_VERSION=${{github.ref_name}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install required packages
       shell: bash
       run: |
-        sudo apt install --no-install-recommends -y gcc-arm-none-eabi libnewlib-arm-none-eabi openscad
+        sudo apt install --no-install-recommends -y gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib openscad
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DPICO_CEC_VERSION=${{github.ref_name}}

--- a/src/hdmi-ddc.c
+++ b/src/hdmi-ddc.c
@@ -139,7 +139,7 @@ uint16_t ddc_get_physical_address(void) {
   // issue a DDC reset
   int ret = i2c_write_timeout_us(i2c_default, EDID_I2C_ADDR, &zero, 1, true, EDID_I2C_TIMEOUT_US);
   if (ret != 1) {
-    printf("Failed to write DDC reset\n");
+    printf("Failed to write DDC reset: %s\n", ret == PICO_ERROR_TIMEOUT ? "timeout" : "generic");
     return 0x0000;
   }
 


### PR DESCRIPTION
Handle the 'Request Active Source' message.
Display code if CEC message is unmapped.

Fix message mapping of '0x46' to 'Give OSD Name'.

Improve DDC reset error, distinguish between error and timeout.

Refactor log handling to reduce duplication.
Reformat logs to be more consistent.
Add millisecond timestamp to log messages.