### PR TITLE
Update pico-sdk and disable SMP

### DIFF
--- a/include/FreeRTOSConfig.h
+++ b/include/FreeRTOSConfig.h
@@ -71,11 +71,11 @@
 #define configSUPPORT_STATIC_ALLOCATION 1
 #define configSUPPORT_DYNAMIC_ALLOCATION 0
 
-#define configNUMBER_OF_CORES 2
+#define configNUMBER_OF_CORES 1
 #define configTICK_CORE 0
-#define configUSE_CORE_AFFINITY 1
-#define configSUPPORT_PICO_SYNC_INTEROP 1
-#define configSUPPORT_PICO_TIME_INTEROP 1
+#define configUSE_CORE_AFFINITY 0
+#define configSUPPORT_PICO_SYNC_INTEROP 0
+#define configSUPPORT_PICO_TIME_INTEROP 0
 
 /* Hook function related definitions. */
 #define configUSE_PASSIVE_IDLE_HOOK 0

--- a/src/debug.c
+++ b/src/debug.c
@@ -52,9 +52,8 @@ int main() {
   xCECTask = xTaskCreateStatic(cec_task, CEC_TASK_NAME, CEC_STACK_SIZE, &cec_q,
                                configMAX_PRIORITIES - 1, &stackCEC[0], &xCECTCB);
 
-  // bind CEC, blink and HID to core 0
-  vTaskCoreAffinitySet(xCECTask, (1 << 0));
-  vTaskCoreAffinitySet(xBlinkTask, (1 << 0));
+  (void)xBlinkTask;
+  (void)xCECTask;
 
   vTaskStartScheduler();
 

--- a/src/main.c
+++ b/src/main.c
@@ -75,14 +75,11 @@ int main() {
   xCDCTask = xTaskCreateStatic(cdc_task, "cdc", CDC_STACK_SIZE, NULL, configMAX_PRIORITIES - 4,
                                &stackCDC[0], &xCDCTCB);
 
-  // bind CEC, blink, HID and CDC to core 0
-  vTaskCoreAffinitySet(xCECTask, (1 << 0));
-  vTaskCoreAffinitySet(xBlinkTask, (1 << 0));
-  vTaskCoreAffinitySet(xHIDTask, (1 << 0));
-  vTaskCoreAffinitySet(xCDCTask, (1 << 0));
-
-  // bind USBD to core 1
-  vTaskCoreAffinitySet(xUSBDTask, (1 << 1));
+  (void)xCECTask;
+  (void)xBlinkTask;
+  (void)xHIDTask;
+  (void)xCDCTask;
+  (void)xUSBDTask;
 
   vTaskStartScheduler();
 

--- a/src/usb_cdc.c
+++ b/src/usb_cdc.c
@@ -20,7 +20,7 @@ static cec_config_t config = {0x0};
 /** Print string to CDC output. */
 static void print(void *arg, const char *str) {
   tud_cdc_write_str(str);
-  vTaskDelay(pdMS_TO_TICKS(1));  // needed to minimise deadlocking
+  vTaskDelay(pdMS_TO_TICKS(1));  // needed to avoid garbled output
 }
 
 /** Print formatted string with variadic parameter list. */


### PR DESCRIPTION
Update to pico-sdk v2.1.1 (and tinyUSB 0.18.0).
Disable FreeRTOS SMP to prevent CDC output deadlocks.