### PR TITLE
Deprecate debug build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,12 +47,13 @@ target_compile_options(tcli PRIVATE
 
 add_executable(${PROJECT}
   src/cec-config.c
+  src/cec-log.c
   src/freertos_hook.c
   src/hdmi-cec.c
   src/hdmi-ddc.c
   src/main.c
   src/nvs.c
-  src/usb_cdc.c
+  src/usb-cdc.c
   src/usb_descriptors.c
   src/usb_hid.c)
 
@@ -66,7 +67,7 @@ set(PICO_CEC_VERSION "unknown" CACHE STRING "Pico-CEC version string.")
 set_source_files_properties(src/hdmi-cec.c PROPERTIES COMPILE_DEFINITIONS
   "CEC_PIN=${CEC_PIN}")
 
-set_source_files_properties(src/usb_cdc.c PROPERTIES COMPILE_DEFINITIONS
+set_source_files_properties(src/usb-cdc.c PROPERTIES COMPILE_DEFINITIONS
   "PICO_CEC_VERSION=\"${PICO_CEC_VERSION}\"")
 
 # Undefine TinyUSB built-in OS, redefined in our tusb_config.h
@@ -91,4 +92,4 @@ pico_set_linker_script(${PROJECT} ${PROJECT_SOURCE_DIR}/src/memmap_ram_nvs.ld)
 pico_enable_stdio_usb(${PROJECT} 0)
 pico_enable_stdio_uart(${PROJECT} 0)
 
-include(debug.cmake)
+#include(debug.cmake)

--- a/include/cec-config.h
+++ b/include/cec-config.h
@@ -26,6 +26,8 @@ typedef struct {
   command_t keymap[UINT8_MAX];
 } cec_config_t;
 
+extern const char *cec_user_control_name[UINT8_MAX];
+
 void cec_config_set_keymap(cec_config_default_t type, cec_config_t *config);
 void cec_config_set_default(cec_config_t *config);
 

--- a/include/cec-log.h
+++ b/include/cec-log.h
@@ -1,0 +1,11 @@
+#ifndef CEC_LOG_H
+#define CEC_LOG_H
+
+void cec_log_init(void);
+bool cec_log_enabled();
+void cec_log_enable(void);
+void cec_log_disable(void);
+void cec_log_vsubmitf(const char *fmt, va_list ap);
+__attribute__((format(printf, 1, 2))) void cec_log_submitf(const char *fmt, ...);
+
+#endif

--- a/include/usb-cdc.h
+++ b/include/usb-cdc.h
@@ -1,0 +1,14 @@
+#ifndef USB_CDC_H
+#define USB_CDC_H
+
+#define _CDC_BR "\r\n"
+
+/** Print formatted string to USB-CDC output. */
+__attribute__((format(printf, 1, 2))) void cdc_printf(const char *fmt, ...);
+
+/** Line print formatted string to USB-CDC output. */
+__attribute__((format(printf, 1, 2))) void cdc_printfln(const char *fmt, ...);
+
+void cdc_log(const char *str);
+
+#endif

--- a/src/cec-config.c
+++ b/src/cec-config.c
@@ -10,7 +10,7 @@
  *
  * @note Incomplete.
  */
-static const char *cec_user_control_name[UINT8_MAX] = {
+const char *cec_user_control_name[UINT8_MAX] = {
     [0x00] = "Select",
     [0x01] = "Up",
     [0x02] = "Down",

--- a/src/cec-log.c
+++ b/src/cec-log.c
@@ -1,0 +1,72 @@
+#include <stdarg.h>
+#include <stdio.h>
+
+#include "FreeRTOS.h"
+#include "message_buffer.h"
+#include "task.h"
+
+#include "cec-log.h"
+#include "usb-cdc.h"
+
+#define LOG_TASK_STACK_SIZE (2048)
+#define LOG_LINE_LENGTH (64)
+#define LOG_QUEUE_LENGTH (16)
+#define LOG_MB_SIZE (LOG_LINE_LENGTH * LOG_QUEUE_LENGTH)
+
+static StaticTask_t log_task_static;
+static StackType_t log_stack[LOG_TASK_STACK_SIZE];
+
+static StaticMessageBuffer_t log_mb_static;
+static MessageBufferHandle_t log_mb;
+static uint8_t log_mb_storage[LOG_MB_SIZE];
+
+static volatile bool enabled = false;
+
+static void cec_log_task(void *param) {
+  while (true) {
+    char buffer[LOG_LINE_LENGTH];
+
+    size_t bytes = xMessageBufferReceive(log_mb, buffer, sizeof(buffer), pdMS_TO_TICKS(10));
+    if (bytes > 0) {
+      cdc_log(buffer);
+    }
+  }
+}
+
+void cec_log_init(void) {
+  log_mb = xMessageBufferCreateStatic(LOG_MB_SIZE, &log_mb_storage[0], &log_mb_static);
+  enabled = false;
+
+  xTaskCreateStatic(cec_log_task, "log", LOG_TASK_STACK_SIZE, NULL, configMAX_PRIORITIES - 4,
+                    &log_stack[0], &log_task_static);
+}
+
+bool cec_log_enabled(void) {
+  return enabled;
+}
+
+void cec_log_enable(void) {
+  enabled = true;
+}
+
+void cec_log_disable(void) {
+  enabled = false;
+}
+
+void cec_log_vsubmitf(const char *fmt, va_list ap) {
+  if (enabled) {
+    char buffer[LOG_LINE_LENGTH];
+
+    int bytes = vsnprintf(buffer, sizeof(buffer), fmt, ap);
+    if (bytes < sizeof(buffer)) {
+      xMessageBufferSend(log_mb, buffer, bytes + 1, pdMS_TO_TICKS(20));
+    }
+  }
+}
+
+void cec_log_submitf(const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  cec_log_vsubmitf(fmt, ap);
+  va_end(ap);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -8,14 +8,16 @@
 #include "hardware/timer.h"
 #include "pico/stdlib.h"
 
+#include "cec-log.h"
 #include "hdmi-cec.h"
+#include "usb-cdc.h"
 #include "usb_hid.h"
 
 #define USBD_STACK_SIZE (512)
 #define HID_STACK_SIZE (256)
-#define CDC_STACK_SIZE (1024)
+#define CDC_STACK_SIZE (2048)
 #define BLINK_STACK_SIZE (128)
-#define CEC_STACK_SIZE (768)
+#define CEC_STACK_SIZE (2048)
 #define CEC_QUEUE_LENGTH (16)
 
 void blink_task(void *param) {
@@ -72,7 +74,7 @@ int main() {
                                &stackHID[0], &xHIDTCB);
   xUSBDTask = xTaskCreateStatic(usb_device_task, "usbd", USBD_STACK_SIZE, NULL,
                                 configMAX_PRIORITIES - 3, &stackUSBD[0], &xUSBDTCB);
-  xCDCTask = xTaskCreateStatic(cdc_task, "cdc", CDC_STACK_SIZE, NULL, configMAX_PRIORITIES - 4,
+  xCDCTask = xTaskCreateStatic(cdc_task, "cdc", CDC_STACK_SIZE, NULL, configMAX_PRIORITIES - 5,
                                &stackCDC[0], &xCDCTCB);
 
   (void)xCECTask;
@@ -80,6 +82,8 @@ int main() {
   (void)xHIDTask;
   (void)xCDCTask;
   (void)xUSBDTask;
+
+  cec_log_init();
 
   vTaskStartScheduler();
 


### PR DESCRIPTION
Implement proper logging through the CLI.
Refactor all CEC frame logging through a timestamped log function.

Add `debug` command to CLI, allowing one to enable or disable debug trace logs at will.