### PR TITLE
Implement RGB status indicator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
+generated
 *.stl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ set(PROJECT pico-cec)
 set(FAMILY rp2040)
 set(BOARD "pico_sdk") # Configure TinyUSB use pico-sdk board configuration
 set(PICO_BOARD "seeed_xiao_rp2040" CACHE STRING "Raspberry Pi Pico board type.")
+#set(PICO_BOARD "waveshare_rp3040_zero" CACHE STRING "Raspberry Pi Pico board type.")
 #set(PICO_BOARD "pico" CACHE STRING "Raspberry Pi Pico board type.")
 
 # Include pico-sdk and tinyusb (must be before project)
@@ -46,6 +47,7 @@ target_compile_options(tcli PRIVATE
   -Wno-stringop-truncation)
 
 add_executable(${PROJECT}
+  src/blink.c
   src/cec-config.c
   src/cec-log.c
   src/freertos_hook.c
@@ -55,11 +57,18 @@ add_executable(${PROJECT}
   src/nvs.c
   src/usb-cdc.c
   src/usb_descriptors.c
-  src/usb_hid.c)
+  src/usb_hid.c
+  src/ws2812.c
+  src/ws2812.pio)
+
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated)
+
+pico_generate_pio_header(${PROJECT} ${PROJECT_SOURCE_DIR}/src/ws2812.pio OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated)
 
 target_include_directories(${PROJECT} PRIVATE
   ${PROJECT_SOURCE_DIR}/include
-  ${PROJECT_SOURCE_DIR}/include/tusb)
+  ${PROJECT_SOURCE_DIR}/include/tusb
+  ${CMAKE_CURRENT_BINARY_DIR}/generated)
 
 set(CEC_PIN "3" CACHE STRING "GPIO pin for HDMI CEC.")
 set(PICO_CEC_VERSION "unknown" CACHE STRING "Pico-CEC version string.")
@@ -79,6 +88,7 @@ target_link_libraries(${PROJECT}
   pico_stdlib
   pico_unique_id
   hardware_i2c
+  hardware_pio
   tinyusb_device
   tinyusb_board
   FreeRTOS-Kernel

--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ this can be written to the Pico as per normal:
 A command line interface over serial port is available, the guide can be found
 here: [Command Line Interface Guide](https://github.com/gkoh/pico-cec/wiki/Command-Line-Interface-Guide)
 
+## Blinking Lights
+The RGB LED provides basic functional diagnosis:
+* blue 2Hz: idle, CEC standby
+* green 2Hz: CEC active
+* green flash: CEC user button pressed
+* red: crash
+
+If there are no lights, something is very wrong.
+If this occurs, please consider raising an issue.
+
 # Real World Usage
 This is currently working with:
 * a Sharp 60" TV (physical address 0x1000)
@@ -211,13 +221,8 @@ https://github.com/gkoh/pico-cec/wiki/Command-Line-Interface-Guide
 In particular, `debug on` will log all CEC traffic to the terminal.
 
 # Future
-* more blinken LEDs
-   * most Pico boards appear to have an RGB LED, use it
-   * perhaps:
-      * R - FreeRTOS crash handlers?
-      * G - HDMI message received?
-      * B - HID keyboard message sent?
 * port to ESP32?
+   * WS2812 driver will need platform support, perhaps to RMT
 
 # References
 Inspiration and/or ground work was obtained from the following:

--- a/include/blink.h
+++ b/include/blink.h
@@ -1,0 +1,21 @@
+#ifndef BLINK_H
+
+#include "FreeRTOS.h"
+#include "task.h"
+
+typedef enum {
+  BLINK_STATE_BLUE_2HZ,
+  BLINK_STATE_GREEN_2HZ,
+  BLINK_STATE_RED_2HZ,
+  BLINK_STATE_GREEN_ON,
+  BLINK_STATE_OFF,
+} blink_state_t;
+
+extern TaskHandle_t xBlinkTask;
+
+void blink_init(void);
+void blink_task(void *param);
+void blink_set(blink_state_t state);
+void blink_set_blink(blink_state_t state);
+
+#endif

--- a/include/ws2812.h
+++ b/include/ws2812.h
@@ -1,0 +1,11 @@
+// From LaserBearIndustries 2025
+#ifndef WS2812_H
+#define WS2812_H
+
+#include <stdint.h>
+
+void ws2812_init(unsigned int pin);
+void ws2812_put_rgb(uint8_t red, uint8_t green, uint8_t blue);
+void ws2812_put_pixel(uint32_t pixel_grb);
+
+#endif  // WS2812_H

--- a/src/blink.c
+++ b/src/blink.c
@@ -1,0 +1,83 @@
+#include "bsp/board.h"
+#include "pico/stdlib.h"
+
+#include "ws2812.h"
+
+#include "blink.h"
+
+TaskHandle_t xBlinkTask;
+
+void blink_init(void) {
+#ifdef PICO_DEFAULT_WS2812_POWER_PIN
+  gpio_init(PICO_DEFAULT_WS2812_POWER_PIN);
+  gpio_set_dir(PICO_DEFAULT_WS2812_POWER_PIN, GPIO_OUT);
+  gpio_put(PICO_DEFAULT_WS2812_POWER_PIN, true);
+#endif
+
+  // RGB = solid green on boot
+  ws2812_init(PICO_DEFAULT_WS2812_PIN);
+  ws2812_put_rgb(0, 0x78, 0);
+
+  gpio_init(PICO_DEFAULT_LED_PIN);
+  gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);
+}
+
+void blink_set(blink_state_t state) {
+  switch (state) {
+    case BLINK_STATE_GREEN_ON:
+      ws2812_put_rgb(0, 0x78, 0);
+      break;
+    case BLINK_STATE_OFF:
+      ws2812_put_rgb(0, 0, 0);
+      break;
+    default:
+      break;
+  }
+}
+
+void blink_set_blink(blink_state_t state) {
+  xTaskNotify(xBlinkTask, (uint32_t)state, eSetValueWithOverwrite);
+}
+
+void blink_task(void *param) {
+  uint32_t blink_delay = 1000;
+  bool state = true;
+  blink_state_t rgb_state = BLINK_STATE_BLUE_2HZ;
+
+  ws2812_put_rgb(0, 0, 0);
+
+  while (true) {
+    uint32_t new_rgb = 0;
+
+    if (xTaskNotifyWait(0, UINT32_MAX, &new_rgb, 1) == pdTRUE) {
+      rgb_state = new_rgb;
+    }
+
+    // heartbeat
+    gpio_put(PICO_DEFAULT_LED_PIN, state);
+
+    // RGB
+    if (state) {
+      switch (rgb_state) {
+        case BLINK_STATE_BLUE_2HZ:
+          ws2812_put_rgb(0, 0, 0x78);
+          break;
+        case BLINK_STATE_GREEN_2HZ:
+          ws2812_put_rgb(0, 0x78, 0);
+          break;
+        case BLINK_STATE_RED_2HZ:
+          ws2812_put_rgb(0x78, 0, 0);
+          break;
+        default:
+          // do nothing
+          break;
+      }
+    } else {
+      ws2812_put_rgb(0, 0, 0);
+    }
+
+    state = !state;
+
+    vTaskDelay(pdMS_TO_TICKS(blink_delay));
+  }
+}

--- a/src/cec-log.c
+++ b/src/cec-log.c
@@ -8,7 +8,7 @@
 #include "cec-log.h"
 #include "usb-cdc.h"
 
-#define LOG_TASK_STACK_SIZE (2048)
+#define LOG_TASK_STACK_SIZE (1024)
 #define LOG_LINE_LENGTH (64)
 #define LOG_QUEUE_LENGTH (16)
 #define LOG_MB_SIZE (LOG_LINE_LENGTH * LOG_QUEUE_LENGTH)

--- a/src/freertos_hook.c
+++ b/src/freertos_hook.c
@@ -30,9 +30,14 @@
 #include "common/tusb_common.h"
 #include "task.h"
 
+#include "ws2812.h"
+
 void vApplicationStackOverflowHook(xTaskHandle pxTask, char *pcTaskName) {
   (void)pxTask;
   (void)pcTaskName;
+
+  // solid red on RGB to indicate overflow
+  ws2812_put_rgb(0x78, 0, 0);
 
   taskDISABLE_INTERRUPTS();
   TU_ASSERT(false, );

--- a/src/main.c
+++ b/src/main.c
@@ -8,28 +8,19 @@
 #include "hardware/timer.h"
 #include "pico/stdlib.h"
 
+#include "blink.h"
 #include "cec-log.h"
 #include "hdmi-cec.h"
 #include "usb-cdc.h"
 #include "usb_hid.h"
+#include "ws2812.h"
 
 #define USBD_STACK_SIZE (512)
 #define HID_STACK_SIZE (256)
-#define CDC_STACK_SIZE (2048)
+#define CDC_STACK_SIZE (1024)
 #define BLINK_STACK_SIZE (128)
-#define CEC_STACK_SIZE (2048)
+#define CEC_STACK_SIZE (1024)
 #define CEC_QUEUE_LENGTH (16)
-
-void blink_task(void *param) {
-  static uint32_t blink_delay = 1000;
-  static bool state = true;
-
-  while (true) {
-    gpio_put(PICO_DEFAULT_LED_PIN, state);
-    state = !state;
-    vTaskDelay(pdMS_TO_TICKS(blink_delay));
-  }
-}
 
 void cdc_task(void *param);
 
@@ -49,18 +40,16 @@ int main() {
   static StaticTask_t xUSBDTCB;
   static StaticTask_t xCDCTCB;
 
-  static TaskHandle_t xBlinkTask;
   static TaskHandle_t xUSBDTask;
   static TaskHandle_t xHIDTask;
   static TaskHandle_t xCDCTask;
+
+  blink_init();
 
   stdio_init_all();
   board_init();
 
   alarm_pool_init_default();
-
-  gpio_init(PICO_DEFAULT_LED_PIN);
-  gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);
 
   // HID key queue
   QueueHandle_t cec_q =

--- a/src/usb-cdc.c
+++ b/src/usb-cdc.c
@@ -109,7 +109,7 @@ static int show_config(void) {
   return 0;
 }
 
-static int show_stats_cec(void *arg) {
+static int show_stats_cec(void) {
   hdmi_cec_stats_t stats = {0x0};
   cec_get_stats(&stats);
   cdc_printfln("%-13s: %lu frames", "CEC rx", stats.rx_frames);
@@ -120,7 +120,7 @@ static int show_stats_cec(void *arg) {
   return 0;
 }
 
-static int show_stats_cpu(void *arg) {
+static int show_stats_cpu(void) {
   UBaseType_t count = uxTaskGetNumberOfTasks();
   TaskStatus_t status[count];
   unsigned long total_run_time = 0;
@@ -145,6 +145,22 @@ static int show_stats_cpu(void *arg) {
   return 0;
 }
 
+static int show_stats_tasks(void) {
+  UBaseType_t count = uxTaskGetNumberOfTasks();
+  TaskStatus_t status[count];
+
+  UBaseType_t n = uxTaskGetSystemState(status, count, NULL);
+
+  cdc_printfln("%-13s | %-10s | %-10s", "task", "priority", "stack (min)");
+
+  for (UBaseType_t i = 0; i < n; i++) {
+    cdc_printfln("%-13s | %-10lu | %-10lu", status[i].pcTaskName, status[i].uxCurrentPriority,
+                 status[i].usStackHighWaterMark);
+  }
+
+  return 0;
+}
+
 static int exec_show(void *arg, int argc, const char **argv) {
   if (argc == 2) {
     if (strcmp(argv[1], "config") == 0) {
@@ -164,9 +180,11 @@ static int exec_show(void *arg, int argc, const char **argv) {
   } else if (argc == 3) {
     if (strcmp(argv[1], "stats") == 0) {
       if (strcmp(argv[2], "cec") == 0) {
-        return show_stats_cec(arg);
+        return show_stats_cec();
       } else if (strcmp(argv[2], "cpu") == 0) {
-        return show_stats_cpu(arg);
+        return show_stats_cpu();
+      } else if (strcmp(argv[2], "tasks") == 0) {
+        return show_stats_tasks();
       }
     }
   }
@@ -234,7 +252,8 @@ static const tclie_cmd_t cmds[] = {
     {"save", exec_save, "Save configuration.", "save"},
     {"set", exec_set, "Set configuration parameters.",
      "set {(config edid_delay_ms|physical_address <value>)|(keymap <value>)}"},
-    {"show", exec_show, "Show information.", "show {cec|config|keymap|(stats {cec|cpu})|version}"},
+    {"show", exec_show, "Show information.",
+     "show {cec|config|keymap|(stats {cec|cpu|tasks})|version}"},
     {"reboot", exec_reboot, "Reboot system.", "reboot [bootsel]"},
 };
 

--- a/src/ws2812.c
+++ b/src/ws2812.c
@@ -1,0 +1,35 @@
+// From LaserBearIndustries 2025
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "hardware/clocks.h"
+#include "hardware/pio.h"
+#include "pico/sem.h"
+#include "pico/stdlib.h"
+#include "ws2812.h"
+#include "ws2812.pio.h"
+
+static semaphore_t mutex;
+
+void ws2812_put_pixel(uint32_t pixel_grb) {
+  // don't block, cannot delay CEC handling
+  if (sem_try_acquire(&mutex)) {
+    pio_sm_put_blocking(pio0, 0, pixel_grb << 8u);
+    sem_release(&mutex);
+  }
+}
+void ws2812_put_rgb(uint8_t red, uint8_t green, uint8_t blue) {
+  uint32_t mask = (green << 16) | (red << 8) | (blue << 0);
+  ws2812_put_pixel(mask);
+}
+
+void ws2812_init(unsigned int pin) {
+  sem_init(&mutex, 1, 1);
+
+  // Get the default PIO (PIO0) and allocate a state machine (SM0)
+  PIO pio = pio0;
+  int sm = 0;
+  uint offset = pio_add_program(pio, &ws2812_program);
+
+  ws2812_program_init(pio, sm, offset, pin, 800000, true);
+}

--- a/src/ws2812.pio
+++ b/src/ws2812.pio
@@ -1,0 +1,48 @@
+;
+; Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+;
+; SPDX-License-Identifier: BSD-3-Clause
+;
+
+.program ws2812
+.side_set 1
+
+.define public T1 2
+.define public T2 5
+.define public T3 3
+
+.lang_opt python sideset_init = pico.PIO.OUT_HIGH
+.lang_opt python out_init     = pico.PIO.OUT_HIGH
+.lang_opt python out_shiftdir = 1
+
+.wrap_target
+bitloop:
+    out x, 1       side 0 [T3 - 1] ; Side-set still takes place when instruction stalls
+    jmp !x do_zero side 1 [T1 - 1] ; Branch on the bit we shifted out. Positive pulse
+do_one:
+    jmp  bitloop   side 1 [T2 - 1] ; Continue driving high, for a long pulse
+do_zero:
+    nop            side 0 [T2 - 1] ; Or drive low, for a short pulse
+.wrap
+
+% c-sdk {
+#include "hardware/clocks.h"
+
+static inline void ws2812_program_init(PIO pio, uint sm, uint offset, uint pin, float freq, bool rgbw) {
+
+    pio_gpio_init(pio, pin);
+    pio_sm_set_consecutive_pindirs(pio, sm, pin, 1, true);
+
+    pio_sm_config c = ws2812_program_get_default_config(offset);
+    sm_config_set_sideset_pins(&c, pin);
+    sm_config_set_out_shift(&c, false, true, rgbw ? 32 : 24);
+    sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_TX);
+
+    int cycles_per_bit = ws2812_T1 + ws2812_T2 + ws2812_T3;
+    float div = clock_get_hz(clk_sys) / (freq * cycles_per_bit);
+    sm_config_set_clkdiv(&c, div);
+
+    pio_sm_init(pio, sm, offset, &c);
+    pio_sm_set_enabled(pio, sm, true);
+}
+%}


### PR DESCRIPTION
Add WS2812 LED support from pico-sdk.
This particular driver uses PIO and will need to be ported for other platforms.

Add handling for the following states:
* idle -> blue 2Hz
* CEC display on -> green 2Hz
* user control pressed -> green on
* user control released -> green off
* stack overflow -> red on

Add `show stats tasks` for visibility into task priority and stack use. As a result, reduce the stack size of multiple tasks.

Finally, fold the 'undecoded' output into the general CEC log handler.