### PR TITLE
Add default keymap handling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(FAMILY rp2040)
 set(BOARD "pico_sdk") # Configure TinyUSB use pico-sdk board configuration
 set(PICO_BOARD "seeed_xiao_rp2040" CACHE STRING "Raspberry Pi Pico board type.")
 
-#set(PICO_BOARD "waveshare_rp3040_zero" CACHE STRING "Raspberry Pi Pico board type.")
+#set(PICO_BOARD "waveshare_rp2040_zero" CACHE STRING "Raspberry Pi Pico board type.")
 #set(PICO_BOARD "vcc_gnd_yd_2040" CACHE STRING "Raspberry Pi Pico board type.")
 #set(PICO_BOARD "pico" CACHE STRING "Raspberry Pi Pico board type.")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ target_include_directories(${PROJECT} PRIVATE
 
 set(CEC_PIN "3" CACHE STRING "GPIO pin for HDMI CEC.")
 set(PICO_CEC_VERSION "unknown" CACHE STRING "Pico-CEC version string.")
+set(KEYMAP_DEFAULT "KODI" CACHE STRING "Default keymap, specify KODI or MISTER.")
 
 set_source_files_properties(src/hdmi-cec.c PROPERTIES COMPILE_DEFINITIONS
   "CEC_PIN=${CEC_PIN}")
@@ -81,7 +82,8 @@ set_source_files_properties(src/usb-cdc.c PROPERTIES COMPILE_DEFINITIONS
 
 # Undefine TinyUSB built-in OS, redefined in our tusb_config.h
 target_compile_options(${PROJECT} PRIVATE
-  -UCFG_TUSB_OS)
+  -UCFG_TUSB_OS
+  -DKEYMAP_DEFAULT_${KEYMAP_DEFAULT}=1)
 
 target_link_libraries(${PROJECT}
   crc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,12 @@ set(PROJECT pico-cec)
 set(FAMILY rp2040)
 set(BOARD "pico_sdk") # Configure TinyUSB use pico-sdk board configuration
 set(PICO_BOARD "seeed_xiao_rp2040" CACHE STRING "Raspberry Pi Pico board type.")
+
 #set(PICO_BOARD "waveshare_rp3040_zero" CACHE STRING "Raspberry Pi Pico board type.")
+#set(PICO_BOARD "vcc_gnd_yd_2040" CACHE STRING "Raspberry Pi Pico board type.")
 #set(PICO_BOARD "pico" CACHE STRING "Raspberry Pi Pico board type.")
+
+set(PICO_BOARD_HEADER_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include/boards)
 
 # Include pico-sdk and tinyusb (must be before project)
 include(pico-sdk/pico_sdk_init.cmake)

--- a/include/boards/vcc_gnd_yd_2040.h
+++ b/include/boards/vcc_gnd_yd_2040.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * @note Mostly inherited from Seeed XIAO RP2040
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+// pico_cmake_set PICO_PLATFORM=rp2040
+
+#ifndef _BOARDS_VCC_GND_YD_2040_H
+#define _BOARDS_VCC_GND_YD_2040_H
+
+// For board detection
+#define VCC_GND_YD_2040
+
+// On some samples, the xosc can take longer to stabilize than is usual
+#ifndef PICO_XOSC_STARTUP_DELAY_MULTIPLIER
+#define PICO_XOSC_STARTUP_DELAY_MULTIPLIER 64
+#endif
+
+//------------- UART -------------//
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+//------------- LED -------------//
+#ifndef PICO_DEFAULT_LED_PIN
+#define PICO_DEFAULT_LED_PIN 25
+#endif
+
+#ifndef PICO_DEFAULT_LED_PIN_INVERTED
+#define PICO_DEFAULT_LED_PIN_INVERTED 0
+#endif
+
+#ifndef PICO_DEFAULT_WS2812_PIN
+#define PICO_DEFAULT_WS2812_PIN 23
+#endif
+
+//------------- I2C -------------//
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 1
+#endif
+
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 6
+#endif
+
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 7
+#endif
+
+//------------- SPI -------------//
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 3
+#endif
+
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 4
+#endif
+
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 2
+#endif
+
+//------------- FLASH -------------//
+
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+// pico_cmake_set_default PICO_FLASH_SIZE_BYTES = (2 * 1024 * 1024)
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (2 * 1024 * 1024)
+#endif
+// All boards have B1 RP2040
+#ifndef PICO_RP2040_B0_SUPPORTED
+#define PICO_RP2040_B0_SUPPORTED 0
+#endif
+
+#endif

--- a/include/cec-config.h
+++ b/include/cec-config.h
@@ -1,6 +1,7 @@
 #ifndef CEC_CONFIG_H
 #define CEC_CONFIG_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 typedef struct {
@@ -9,8 +10,10 @@ typedef struct {
 } command_t;
 
 typedef enum {
-  CEC_CONFIG_DEFAULT_KODI = 0,
-} cec_config_default_t;
+  CEC_CONFIG_KEYMAP_CUSTOM = 0,
+  CEC_CONFIG_KEYMAP_KODI = 1,
+  CEC_CONFIG_KEYMAP_MISTER = 2,
+} cec_config_keymap_t;
 
 /**
  * CEC configuration in-memory.
@@ -22,13 +25,63 @@ typedef struct {
   /** CEC physical address. */
   uint16_t physical_address;
 
+  /** CEC logical address. */
+  uint8_t logical_address;
+
+  /** Keymap configuration. */
+  cec_config_keymap_t keymap_type;
+
   /** User Control key mapping table. */
   command_t keymap[UINT8_MAX];
 } cec_config_t;
 
+/**
+ * CEC user command codes.
+ *
+ * @note Incomplete, add as needed.
+ */
+typedef enum {
+  CEC_USER_SELECT = 0x00,
+  CEC_USER_UP = 0x01,
+  CEC_USER_DOWN = 0x02,
+  CEC_USER_LEFT = 0x03,
+  CEC_USER_RIGHT = 0x04,
+  CEC_USER_RIGHT_UP = 0x05,
+  CEC_USER_RIGHT_DOWN = 0x06,
+  CEC_USER_LEFT_UP = 0x07,
+  CEC_USER_LEFT_DOWN = 0x08,
+  CEC_USER_OPTIONS = 0x0a,
+  CEC_USER_EXIT = 0x0d,
+  CEC_USER_0 = 0x20,
+  CEC_USER_1 = 0x21,
+  CEC_USER_2 = 0x22,
+  CEC_USER_3 = 0x23,
+  CEC_USER_4 = 0x24,
+  CEC_USER_5 = 0x25,
+  CEC_USER_6 = 0x26,
+  CEC_USER_7 = 0x27,
+  CEC_USER_8 = 0x28,
+  CEC_USER_9 = 0x29,
+  CEC_USER_DISPLAY_INFO = 0x35,
+  CEC_USER_VOLUME_UP = 0x41,
+  CEC_USER_VOLUME_DOWN = 0x42,
+  CEC_USER_PLAY = 0x44,
+  CEC_USER_STOP = 0x45,
+  CEC_USER_PAUSE = 0x46,
+  CEC_USER_REWIND = 0x48,
+  CEC_USER_FAST_FWD = 0x49,
+  CEC_USER_SUB_PICTURE = 0x51,
+  CEC_USER_F1_BLUE = 0x71,
+  CEC_USER_F2_RED = 0x72,
+  CEC_USER_F3_GREEN = 0x73,
+  CEC_USER_F4_YELLOW = 0x74,
+  CEC_USER_F5 = 0x75,
+} cec_user_t;
+
+/** Mapping from CEC user code to human readable string. */
 extern const char *cec_user_control_name[UINT8_MAX];
 
-void cec_config_set_keymap(cec_config_default_t type, cec_config_t *config);
+void cec_config_set_keymap(cec_config_t *config);
 void cec_config_set_default(cec_config_t *config);
 
 void cec_config_complete(cec_config_t *config);

--- a/include/cec-config.h
+++ b/include/cec-config.h
@@ -28,6 +28,9 @@ typedef struct {
   /** CEC logical address. */
   uint8_t logical_address;
 
+  /** CEC device type. */
+  uint8_t device_type;
+
   /** Keymap configuration. */
   cec_config_keymap_t keymap_type;
 

--- a/include/nvs.h
+++ b/include/nvs.h
@@ -5,7 +5,13 @@
 
 #include "cec-config.h"
 
+/** Read configuration from NVS. */
+bool nvs_read_config(cec_config_t *config);
+
+/** Read and apply configuration from NVS. */
 void nvs_load_config(cec_config_t *config);
+
+/** Save configuration to NVS. */
 bool nvs_save_config(const cec_config_t *config);
 
 #endif

--- a/src/cec-config.c
+++ b/src/cec-config.c
@@ -8,44 +8,44 @@
  * From "High-Definition Multimedia Interface Specification Version 1.3, CEC
  * Table 23, User Control Codes, p. 62"
  *
- * @note Incomplete.
+ * @note Incomplete, add as required.
  */
 const char *cec_user_control_name[UINT8_MAX] = {
-    [0x00] = "Select",
-    [0x01] = "Up",
-    [0x02] = "Down",
-    [0x03] = "Left",
-    [0x04] = "Right",
-    [0x05] = "Right-Up",
-    [0x06] = "Right-Down",
-    [0x07] = "Left-Up",
-    [0x08] = "Left-Down",
-    [0x0a] = "Options",
-    [0x0d] = "Exit",
-    [0x20] = "0",
-    [0x21] = "1",
-    [0x22] = "2",
-    [0x23] = "3",
-    [0x24] = "4",
-    [0x25] = "5",
-    [0x26] = "6",
-    [0x27] = "7",
-    [0x28] = "8",
-    [0x29] = "9",
-    [0x35] = "Display Information",
-    [0x41] = "Volume Up",
-    [0x42] = "Volume Down",
-    [0x44] = "Play",
-    [0x45] = "Stop",
-    [0x46] = "Pause",
-    [0x48] = "Rewind",
-    [0x49] = "Fast Forward",
-    [0x51] = "Sub Picture",
-    [0x71] = "F1 (Blue)",
-    [0x72] = "F2 (Red)",
-    [0x73] = "F3 (Green)",
-    [0x74] = "F4 (Yellow)",
-    [0x75] = "F5",
+    [CEC_USER_SELECT] = "Select",
+    [CEC_USER_UP] = "Up",
+    [CEC_USER_DOWN] = "Down",
+    [CEC_USER_LEFT] = "Left",
+    [CEC_USER_RIGHT] = "Right",
+    [CEC_USER_RIGHT_UP] = "Right-Up",
+    [CEC_USER_RIGHT_DOWN] = "Right-Down",
+    [CEC_USER_LEFT_UP] = "Left-Up",
+    [CEC_USER_LEFT_DOWN] = "Left-Down",
+    [CEC_USER_OPTIONS] = "Options",
+    [CEC_USER_EXIT] = "Exit",
+    [CEC_USER_0] = "0",
+    [CEC_USER_1] = "1",
+    [CEC_USER_2] = "2",
+    [CEC_USER_3] = "3",
+    [CEC_USER_4] = "4",
+    [CEC_USER_5] = "5",
+    [CEC_USER_6] = "6",
+    [CEC_USER_7] = "7",
+    [CEC_USER_8] = "8",
+    [CEC_USER_9] = "9",
+    [CEC_USER_DISPLAY_INFO] = "Display Information",
+    [CEC_USER_VOLUME_UP] = "Volume Up",
+    [CEC_USER_VOLUME_DOWN] = "Volume Down",
+    [CEC_USER_PLAY] = "Play",
+    [CEC_USER_STOP] = "Stop",
+    [CEC_USER_PAUSE] = "Pause",
+    [CEC_USER_REWIND] = "Rewind",
+    [CEC_USER_FAST_FWD] = "Fast Forward",
+    [CEC_USER_SUB_PICTURE] = "Sub Picture",
+    [CEC_USER_F1_BLUE] = "F1 (Blue)",
+    [CEC_USER_F2_RED] = "F2 (Red)",
+    [CEC_USER_F3_GREEN] = "F3 (Green)",
+    [CEC_USER_F4_YELLOW] = "F4 (Yellow)",
+    [CEC_USER_F5] = "F5",
     NULL,
 };
 
@@ -65,36 +65,73 @@ static const uint32_t default_edid_delay_ms = 5000;
  */
 static const uint16_t default_physical_addr = 0x0000;
 
-/*
+/**
+ * Default logical address.
+ *
+ * @note Currently unused.
+ */
+static const uint8_t default_logical_addr = 0x00;
+
+/**
  * Default (Kodi) key mapping from HDMI user control to HID keyboard entry.
  */
 static const uint8_t default_kodi_user_keymap[UINT8_MAX] = {
-    [0x00] = HID_KEY_ENTER,
-    [0x01] = HID_KEY_ARROW_UP,
-    [0x02] = HID_KEY_ARROW_DOWN,
-    [0x03] = HID_KEY_ARROW_LEFT,
-    [0x04] = HID_KEY_ARROW_RIGHT,
-    [0x0a] = HID_KEY_C,
-    [0x0d] = HID_KEY_BACKSPACE,
-    [0x20] = HID_KEY_0,
-    [0x21] = HID_KEY_1,
-    [0x22] = HID_KEY_2,
-    [0x23] = HID_KEY_3,
-    [0x24] = HID_KEY_4,
-    [0x25] = HID_KEY_5,
-    [0x26] = HID_KEY_6,
-    [0x27] = HID_KEY_7,
-    [0x28] = HID_KEY_8,
-    [0x29] = HID_KEY_9,
-    [0x35] = HID_KEY_I,
-    [0x44] = HID_KEY_P,
-    [0x45] = HID_KEY_X,
-    [0x46] = HID_KEY_SPACE,
-    [0x48] = HID_KEY_R,
-    [0x49] = HID_KEY_F,
-    [0x51] = HID_KEY_L,
+    [CEC_USER_SELECT] = HID_KEY_ENTER,
+    [CEC_USER_UP] = HID_KEY_ARROW_UP,
+    [CEC_USER_DOWN] = HID_KEY_ARROW_DOWN,
+    [CEC_USER_LEFT] = HID_KEY_ARROW_LEFT,
+    [CEC_USER_RIGHT] = HID_KEY_ARROW_RIGHT,
+    [CEC_USER_OPTIONS] = HID_KEY_C,
+    [CEC_USER_EXIT] = HID_KEY_BACKSPACE,
+    [CEC_USER_0] = HID_KEY_0,
+    [CEC_USER_1] = HID_KEY_1,
+    [CEC_USER_2] = HID_KEY_2,
+    [CEC_USER_3] = HID_KEY_3,
+    [CEC_USER_4] = HID_KEY_4,
+    [CEC_USER_5] = HID_KEY_5,
+    [CEC_USER_6] = HID_KEY_6,
+    [CEC_USER_7] = HID_KEY_7,
+    [CEC_USER_8] = HID_KEY_8,
+    [CEC_USER_9] = HID_KEY_9,
+    [CEC_USER_DISPLAY_INFO] = HID_KEY_I,
+    [CEC_USER_PLAY] = HID_KEY_P,
+    [CEC_USER_STOP] = HID_KEY_X,
+    [CEC_USER_PAUSE] = HID_KEY_SPACE,
+    [CEC_USER_REWIND] = HID_KEY_R,
+    [CEC_USER_FAST_FWD] = HID_KEY_F,
+    [CEC_USER_SUB_PICTURE] = HID_KEY_L,
     0x00,
 };
+
+/**
+ * Key mapping for MiSTer integration, from LaserBearIndustries.
+ */
+static const uint8_t default_mister_user_keymap[UINT8_MAX] = {
+    [CEC_USER_SELECT] = HID_KEY_ENTER,
+    [CEC_USER_UP] = HID_KEY_ARROW_UP,
+    [CEC_USER_DOWN] = HID_KEY_ARROW_DOWN,
+    [CEC_USER_LEFT] = HID_KEY_ARROW_LEFT,
+    [CEC_USER_RIGHT] = HID_KEY_ARROW_RIGHT,
+    [CEC_USER_OPTIONS] = HID_KEY_F12,
+    [CEC_USER_EXIT] = HID_KEY_F12,
+    [CEC_USER_0] = HID_KEY_0,
+    [CEC_USER_1] = HID_KEY_1,
+    [CEC_USER_2] = HID_KEY_2,
+    [CEC_USER_3] = HID_KEY_3,
+    [CEC_USER_4] = HID_KEY_4,
+    [CEC_USER_5] = HID_KEY_5,
+    [CEC_USER_6] = HID_KEY_6,
+    [CEC_USER_7] = HID_KEY_7,
+    [CEC_USER_8] = HID_KEY_8,
+    [CEC_USER_9] = HID_KEY_9,
+    [CEC_USER_DISPLAY_INFO] = HID_KEY_I,
+    [CEC_USER_PLAY] = HID_KEY_F12,
+    [CEC_USER_STOP] = HID_KEY_F12,
+    [CEC_USER_PAUSE] = HID_KEY_F12,
+    [CEC_USER_REWIND] = HID_KEY_F12,
+    [CEC_USER_FAST_FWD] = HID_KEY_F12,
+    [CEC_USER_SUB_PICTURE] = HID_KEY_L,
+    0x00};
 
 void cec_config_set_default(cec_config_t *config) {
   if (config == NULL) {
@@ -102,18 +139,31 @@ void cec_config_set_default(cec_config_t *config) {
   }
   config->edid_delay_ms = default_edid_delay_ms;
   config->physical_address = default_physical_addr;
+  config->logical_address = default_logical_addr;
+#if KEYMAP_DEFAULT_KODI
+  config->keymap_type = CEC_CONFIG_KEYMAP_KODI;
+#elif KEYMAP_DEFAULT_MISTER
+  config->keymap_type = CEC_CONFIG_KEYMAP_MISTER;
+#else
+#error "Unknown default keymap."
+#endif
 }
 
-void cec_config_set_keymap(cec_config_default_t type, cec_config_t *config) {
+void cec_config_set_keymap(cec_config_t *config) {
   if (config == NULL) {
     return;
   }
 
   const uint8_t *default_keymap = NULL;
 
-  switch (type) {
-    case CEC_CONFIG_DEFAULT_KODI:
+  switch (config->keymap_type) {
+    case CEC_CONFIG_KEYMAP_CUSTOM:
+      break;
+    case CEC_CONFIG_KEYMAP_KODI:
       default_keymap = &default_kodi_user_keymap[0];
+      break;
+    case CEC_CONFIG_KEYMAP_MISTER:
+      default_keymap = &default_mister_user_keymap[0];
       break;
     default:
       return;

--- a/src/cec-config.c
+++ b/src/cec-config.c
@@ -140,6 +140,7 @@ void cec_config_set_default(cec_config_t *config) {
   config->edid_delay_ms = default_edid_delay_ms;
   config->physical_address = default_physical_addr;
   config->logical_address = default_logical_addr;
+  config->device_type = 0;
 #if KEYMAP_DEFAULT_KODI
   config->keymap_type = CEC_CONFIG_KEYMAP_KODI;
 #elif KEYMAP_DEFAULT_MISTER

--- a/src/nvs.c
+++ b/src/nvs.c
@@ -22,6 +22,22 @@ typedef struct __attribute__((packed)) {
 } cec_config_header_nvs_t;
 
 /**
+ * CEC configuration block NVS representation (version 1)
+ *
+ * Structure is packed to ensure checksum correctness.
+ */
+typedef struct __attribute__((packed)) {
+  /** DDC EDID delay in milliseconds. */
+  uint32_t edid_delay_ms;
+
+  /** CEC physical address. */
+  uint16_t physical_address;
+
+  /** User Control key mapping table. */
+  uint8_t keymap[UINT8_MAX];
+} cec_config_nvs_v1_t;
+
+/**
  * CEC configuration block NVS representation.
  *
  * Structure is packed to ensure checksum correctness.
@@ -32,6 +48,12 @@ typedef struct __attribute__((packed)) {
 
   /** CEC physical address. */
   uint16_t physical_address;
+
+  /** CEC logical address. */
+  uint8_t logical_address;
+
+  /** Keymap. */
+  cec_config_keymap_t keymap_type;
 
   /** User Control key mapping table. */
   uint8_t keymap[UINT8_MAX];
@@ -62,30 +84,87 @@ extern uint32_t __CEC_NVS_LEN[];
 
 #define CEC_NVS_LEN ((uint32_t)(&__CEC_NVS_LEN))
 
-const uint8_t CEC_CONFIG_VERSION = 0x01;
+const uint8_t CEC_CONFIG_VERSION_01 = 0x01;
+const uint8_t CEC_CONFIG_VERSION = 0x02;
 const size_t CEC_CONFIG_SIZE = sizeof(cec_config_t);
 
 static uint32_t nvs_get_flash_address(void) {
   return ((uint32_t)CEC_NVS_BASE_ADDR - XIP_BASE);
 }
 
-void nvs_load_config(cec_config_t *config) {
+/**
+ * Migrate v1 config to current config.
+ */
+static bool migrate_v1(const pico_cec_nvs_t *nvs, cec_config_t *config) {
+  if (crc32((unsigned char *)&nvs->config, sizeof(cec_config_nvs_v1_t)) == nvs->config_crc) {
+    cec_config_nvs_v1_t *configv1 = (cec_config_nvs_v1_t *)&nvs->config;
+    // deserialise and migrate
+    config->edid_delay_ms = configv1->edid_delay_ms;
+    config->physical_address = configv1->physical_address;
+    for (uint8_t n = 0; n < UINT8_MAX; n++) {
+      config->keymap[n].key = configv1->keymap[n];
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Load current config.
+ */
+static bool load_config(pico_cec_nvs_t *nvs, cec_config_t *config) {
+  if (crc32((unsigned char *)&nvs->config, sizeof(nvs->config)) == nvs->config_crc) {
+    // deserialise
+    config->edid_delay_ms = nvs->config.edid_delay_ms;
+    config->physical_address = nvs->config.physical_address;
+    config->logical_address = nvs->config.logical_address;
+    config->keymap_type = nvs->config.keymap_type;
+    for (uint8_t n = 0; n < UINT8_MAX; n++) {
+      config->keymap[n].key = nvs->config.keymap[n];
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+bool nvs_read_config(cec_config_t *config) {
+  bool success = false;
+
   // flash is mmapped for read
   pico_cec_nvs_t *cec_nvs = (pico_cec_nvs_t *)(CEC_NVS_BASE_ADDR);
 
+  // start with default config, then overlay from nvs
+  cec_config_set_default(config);
+
   // read and check header/config CRCs
-  if ((crc32((unsigned char *)&cec_nvs->header, sizeof(cec_nvs->header)) == cec_nvs->header_crc)
-      && crc32((unsigned char *)&cec_nvs->config, sizeof(cec_nvs->config)) == cec_nvs->config_crc) {
-    // deserialise
-    config->edid_delay_ms = cec_nvs->config.edid_delay_ms;
-    config->physical_address = cec_nvs->config.physical_address;
-    for (uint8_t n = 0; n < UINT8_MAX; n++) {
-      config->keymap[n].key = cec_nvs->config.keymap[n];
+  if (crc32((unsigned char *)&cec_nvs->header, sizeof(cec_nvs->header)) == cec_nvs->header_crc) {
+    if (cec_nvs->header.version == CEC_CONFIG_VERSION_01) {
+      success = migrate_v1(cec_nvs, config);
+    } else if (cec_nvs->header.version == CEC_CONFIG_VERSION) {
+      success = load_config(cec_nvs, config);
     }
-  } else {
-    // load default kodi config
-    cec_config_set_default(config);
-    cec_config_set_keymap(CEC_CONFIG_DEFAULT_KODI, config);
+  }
+
+  return success;
+}
+
+void nvs_load_config(cec_config_t *config) {
+  nvs_read_config(config);
+
+  switch (config->keymap_type) {
+    case CEC_CONFIG_KEYMAP_KODI:
+    case CEC_CONFIG_KEYMAP_MISTER:
+      cec_config_set_keymap(config);
+      break;
+    case CEC_CONFIG_KEYMAP_CUSTOM:
+      // should already be loaded
+      break;
+    default:
+      break;
   }
 
   cec_config_complete(config);
@@ -108,9 +187,13 @@ bool nvs_save_config(const cec_config_t *config) {
   // serialise and checksum config
   cec_nvs.config.edid_delay_ms = config->edid_delay_ms;
   cec_nvs.config.physical_address = config->physical_address;
+  cec_nvs.config.logical_address = config->logical_address;
+  cec_nvs.config.keymap_type = config->keymap_type;
+
   for (unsigned int n = 0; n < UINT8_MAX; n++) {
     cec_nvs.config.keymap[n] = config->keymap[n].key;
   }
+
   cec_nvs.config_crc = crc32((unsigned char *)&cec_nvs.config, sizeof(cec_nvs.config));
 
   // minimum number of flash sectors to erase in bytes

--- a/src/nvs.c
+++ b/src/nvs.c
@@ -49,8 +49,11 @@ typedef struct __attribute__((packed)) {
   /** CEC physical address. */
   uint16_t physical_address;
 
-  /** CEC logical address. */
+  /** CEC logical address (unused). */
   uint8_t logical_address;
+
+  /** CEC device type (unused). */
+  uint8_t device_type;
 
   /** Keymap. */
   cec_config_keymap_t keymap_type;
@@ -120,6 +123,7 @@ static bool load_config(pico_cec_nvs_t *nvs, cec_config_t *config) {
     config->edid_delay_ms = nvs->config.edid_delay_ms;
     config->physical_address = nvs->config.physical_address;
     config->logical_address = nvs->config.logical_address;
+    config->device_type = nvs->config.device_type;
     config->keymap_type = nvs->config.keymap_type;
     for (uint8_t n = 0; n < UINT8_MAX; n++) {
       config->keymap[n].key = nvs->config.keymap[n];


### PR DESCRIPTION
Add support for updating default keymaps when the user never customises the keymap.
This turned out to be more complicated than I initially realised.

Nonetheless, the following has been done:
* add default keymap loading
* NVS version detection
   * example support for how we could migrate NVS configuration from version to version
* add 'MiSTer' keymap from LaserBearIndustries
* `show nvs` command
* board definition for the YD-2040 development board