### PR TITLE
Introduce monitor (promiscuous) mode

### DIFF
--- a/include/cec-config.h
+++ b/include/cec-config.h
@@ -39,6 +39,9 @@ typedef struct {
   /** CEC device type. */
   uint8_t device_type;
 
+  /** Use CEC monitor mode. (bus analyser) */
+  uint8_t monitor_mode;
+
   /** Keymap configuration. */
   cec_config_keymap_t keymap_type;
 

--- a/include/cec-frame.h
+++ b/include/cec-frame.h
@@ -51,8 +51,11 @@ typedef struct {
 } cec_frame_stats_t;
 
 void cec_frame_init(void);
+void cec_frame_clear_stats(void);
 void cec_frame_get_stats(cec_frame_stats_t *stats);
 bool cec_frame_send(uint8_t pldcnt, uint8_t *pld);
 uint8_t cec_frame_recv(uint8_t *pld, uint8_t address);
+void cec_frame_set_monitor_mode(bool mode);
+bool cec_frame_get_monitor_mode(void);
 
 #endif

--- a/include/cec-log.h
+++ b/include/cec-log.h
@@ -4,9 +4,7 @@
 #include <stdarg.h>
 #include <stdbool.h>
 
-#include "usb-cdc.h"
-
-#define _LOG_BR _CDC_BR
+#define _LOG_BR "\r\n"
 
 typedef struct cec_frame_t cec_frame_t;
 typedef void (*log_callback_t)(const char *str);
@@ -15,10 +13,10 @@ void cec_log_init(log_callback_t log);
 bool cec_log_enabled();
 void cec_log_enable(void);
 void cec_log_disable(void);
+void cec_log(const char *buffer, int len);
+void cec_log_raw_frame(cec_frame_t *frame);
 void cec_log_frame(cec_frame_t *frame, bool recv);
 void cec_log_vsubmitf(const char *fmt, va_list ap);
 __attribute__((format(printf, 1, 2))) void cec_log_submitf(const char *fmt, ...);
-
-uint64_t cec_log_uptime_ms(void);
 
 #endif

--- a/src/cec-config.c
+++ b/src/cec-config.c
@@ -13,6 +13,11 @@
 static const uint32_t default_edid_delay_ms = 5000;
 
 /**
+ * Default monitor mode (on/off).
+ */
+static const uint8_t default_monitor_mode = 0;
+
+/**
  * Default physical address.
  *
  * 0x0000 is typically reserved for the television and we never claim it.
@@ -102,6 +107,7 @@ void cec_config_set_default(cec_config_t *config) {
     return;
   }
   config->edid_delay_ms = default_edid_delay_ms;
+  config->monitor_mode = default_monitor_mode;
   config->physical_address = default_physical_addr;
   config->logical_address = default_logical_addr;
   config->device_type = default_device_type;

--- a/src/cec-frame.c
+++ b/src/cec-frame.c
@@ -19,6 +19,16 @@ static cec_frame_t rx_frame = {.message = &rx_message};
 /* CEC statistics. */
 static cec_frame_stats_t cec_stats;
 
+static bool monitor_mode = false;
+
+void cec_frame_set_monitor_mode(bool mode) {
+  monitor_mode = mode;
+}
+
+bool cec_frame_get_monitor_mode(void) {
+  return monitor_mode;
+}
+
 /**
  * Calculate next offset as time since boot.
  */
@@ -31,12 +41,12 @@ static uint64_t time_next(uint64_t start, uint64_t next) {
  */
 static int64_t ack_high(alarm_id_t alarm, void *user_data) {
   gpio_set_dir(CEC_PIN, GPIO_IN);
-
   return 0;
 }
 
 static void frame_rx_isr(uint gpio, uint32_t events) {
   uint64_t low_time = 0;
+
   gpio_acknowledge_irq(gpio, events);
   gpio_set_irq_enabled(CEC_PIN, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, false);
   // printf("state = %d, byte = %d, bit = %d\n", rx_frame.state, rx_frame.byte, rx_frame.bit);
@@ -113,9 +123,9 @@ static void frame_rx_isr(uint gpio, uint32_t events) {
       rx_frame.start = time_us_64();
       // send ack by changing ack from 1 to 0
       uint8_t tgt_addr = rx_frame.message->data[0] & 0x0f;
-      if ((tgt_addr != 0x0f) && (tgt_addr == rx_frame.address)) {
-        rx_frame.state = CEC_FRAME_STATE_ACK_END;
-        gpio_set_dir(CEC_PIN, GPIO_OUT);  // pull low, then schedule pull high
+      if (!monitor_mode && tgt_addr != 0x0f && tgt_addr == rx_frame.address) {
+        rx_frame.state = CEC_FRAME_STATE_ACK_END;  // TODO: remove, gets overwritten below
+        gpio_set_dir(CEC_PIN, GPIO_OUT);           // pull low, then schedule pull high
         add_alarm_at(from_us_since_boot(rx_frame.start + 1500), ack_high, NULL, true);
         rx_frame.ack = true;
       }
@@ -158,15 +168,16 @@ uint8_t cec_frame_recv(uint8_t *pld, uint8_t address) {
   ulTaskNotifyTakeIndexed(NOTIFY_RX, pdTRUE, portMAX_DELAY);
   memcpy(pld, rx_frame.message->data, rx_frame.message->len);
   // printf("high water mark = %lu\n", uxTaskGetStackHighWaterMark(xCECTask));
-
-  cec_log_frame(&rx_frame, true);
-
+  if (monitor_mode) {
+    cec_log_raw_frame(&rx_frame);
+  } else {
+    cec_log_frame(&rx_frame, true);
+  }
   if (rx_frame.state == CEC_FRAME_STATE_ABORT) {
     // printf("ABORT\n");
     cec_stats.rx_abort_frames++;
     return 0;
   }
-
   cec_stats.rx_frames++;
   return rx_frame.message->len;
 }
@@ -276,9 +287,15 @@ static bool frame_tx(uint8_t *data, uint8_t len) {
 }
 
 bool cec_frame_send(uint8_t pldcnt, uint8_t *pld) {
+  if (monitor_mode)
+    return false;
   // disable GPIO ISR for sending
   gpio_set_irq_enabled(CEC_PIN, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, false);
   return frame_tx(pld, pldcnt);
+}
+
+void cec_frame_clear_stats(void) {
+  memset(&cec_stats, 0, sizeof(cec_stats));
 }
 
 void cec_frame_get_stats(cec_frame_stats_t *stats) {

--- a/src/cec-log.c
+++ b/src/cec-log.c
@@ -60,6 +60,10 @@ void cec_log_disable(void) {
   enabled = false;
 }
 
+void cec_log(const char *buffer, int len) {
+  xMessageBufferSend(log_mb, buffer, len + 1, pdMS_TO_TICKS(20));
+}
+
 void cec_log_vsubmitf(const char *fmt, va_list ap) {
   if (enabled) {
     char buffer[LOG_LINE_LENGTH];
@@ -159,6 +163,27 @@ const char *cec_feature_abort_reason[] = {
 };
 
 /**
+ * Log a raw CEC frame.
+ *
+ * CEC raw frame logging function, formatted suitable for cec-o-matic
+ */
+void cec_log_raw_frame(cec_frame_t *frame) {
+  cec_message_t *msg = frame->message;
+  char buffer[48];
+
+  memset(buffer, 0, sizeof(buffer));
+  if (msg->len > 0) {
+    int j = 0;
+    for (int i = 0; i < msg->len && j < sizeof(buffer); i++, j += 3) {
+      sprintf(&buffer[j], "%02x:", msg->data[i]);
+    }
+    buffer[j - 1] = '\r';
+    buffer[j - 0] = '\n';
+    cec_log(buffer, j + 1);
+  }
+}
+
+/**
  * Log a CEC frame.
  *
  * CEC frame logging function, which includes minor protocol decoding for debug
@@ -227,8 +252,8 @@ void cec_log_frame(cec_frame_t *frame, bool recv) {
         log_printf(initiator, destination, recv, frame->ack, "[%s][%s]", cec_message[cmd], status);
         break;
       default: {
-        const char *message = cec_message[cmd];
-        if (strlen(message) > 0) {
+        const char *message = cec_message[cmd];  // TODO: seems to be problematic for unknown cmd's
+        if (message != NULL && strlen(message) > 0) {
           log_printf(initiator, destination, recv, frame->ack, "[%s]", cec_message[cmd]);
         } else {
           log_printf(initiator, destination, recv, frame->ack, "[%x] (undecoded)", cmd);

--- a/src/cec-task.c
+++ b/src/cec-task.c
@@ -125,7 +125,7 @@ static void report_cec_version(uint8_t initiator, uint8_t destination) {
   cec_frame_send(3, pld);
 }
 
-bool cec_ping(uint8_t destination) {
+static bool cec_ping(uint8_t destination) {
   uint8_t pld[1] = {HEADER0(destination, destination)};
 
   return cec_frame_send(1, pld);
@@ -163,7 +163,7 @@ static uint8_t allocate_logical_address(cec_config_t *config) {
   return a;
 }
 
-uint16_t get_physical_address(const cec_config_t *config) {
+static uint16_t get_physical_address(const cec_config_t *config) {
   return (config->physical_address == 0x0000) ? ddc_get_physical_address()
                                               : config->physical_address;
 }
@@ -181,6 +181,11 @@ void cec_task(void *param) {
 
   // load configuration
   nvs_load_config(&config);
+  if (config.monitor_mode != 0) {
+    cec_frame_set_monitor_mode(true);
+  } else {
+    cec_frame_set_monitor_mode(false);
+  }
 
   // pause for EDID to settle
   vTaskDelay(pdMS_TO_TICKS(config.edid_delay_ms));

--- a/src/nvs.c
+++ b/src/nvs.c
@@ -55,6 +55,9 @@ typedef struct __attribute__((packed)) {
   /** CEC device type (unused). */
   uint8_t device_type;
 
+  /** CEC monitor mode. */
+  uint8_t monitor_mode;
+
   /** Keymap. */
   cec_config_keymap_t keymap_type;
 
@@ -121,6 +124,7 @@ static bool load_config(pico_cec_nvs_t *nvs, cec_config_t *config) {
   if (crc32((unsigned char *)&nvs->config, sizeof(nvs->config)) == nvs->config_crc) {
     // deserialise
     config->edid_delay_ms = nvs->config.edid_delay_ms;
+    config->monitor_mode = nvs->config.monitor_mode;
     config->physical_address = nvs->config.physical_address;
     config->logical_address = nvs->config.logical_address;
     config->device_type = nvs->config.device_type;
@@ -183,6 +187,7 @@ void nvs_load_config(cec_config_t *config) {
 bool nvs_save_config(const cec_config_t *config) {
   pico_cec_nvs_t cec_nvs = {0x0};
 
+  // TODO: it looks like CEC_NVS_LEN is the address of a variable containing a len
   if (sizeof(cec_nvs) > CEC_NVS_LEN) {
     return false;
   }
@@ -194,6 +199,7 @@ bool nvs_save_config(const cec_config_t *config) {
 
   // serialise and checksum config
   cec_nvs.config.edid_delay_ms = config->edid_delay_ms;
+  cec_nvs.config.monitor_mode = config->monitor_mode;
   cec_nvs.config.physical_address = config->physical_address;
   cec_nvs.config.logical_address = config->logical_address;
   cec_nvs.config.device_type = config->device_type;

--- a/src/usb-cdc.c
+++ b/src/usb-cdc.c
@@ -81,6 +81,23 @@ static int exec_debug(void *arg, int argc, const char *argv[]) {
   return -1;
 }
 
+static int exec_monitor(void *arg, int argc, const char *argv[]) {
+  if (argc == 2) {
+    if (strcmp(argv[1], "on") == 0) {
+      cec_frame_set_monitor_mode(true);
+      return 0;
+    } else if (strcmp(argv[1], "off") == 0) {
+      cec_frame_set_monitor_mode(false);
+      // TODO: when we come out of monitor mode, it may be prudent to re-ascertain our cec address,
+      // especially if we started in monitor mode, as our logical address probably defaulted to 0x04
+      // which could result in a bus conflict
+      return 0;
+    }
+  }
+
+  return -1;
+}
+
 static int exec_reboot(void *arg, int argc, const char **argv) {
   if ((argc == 2) && (strcmp(argv[1], "bootsel") == 0)) {
     // reboot into USB bootloader
@@ -110,13 +127,19 @@ static void print_logical_address(uint8_t address) {
   cdc_printfln("%-17s: 0x%02x", "Logical address", address);
 }
 
+static void print_monitor_mode(uint8_t monitor_mode) {
+  cdc_printfln("%-17s: %s", "Monitor mode", monitor_mode ? "on" : "off");
+}
+
 static int show_config(cec_config_t *config) {
   // UBaseType_t uxHighWaterMark = uxTaskGetStackHighWaterMark(NULL);
   // cdc_printfln("StackHighWaterMark = %lu", uxHighWaterMark);
 
   print_edid_delay(config->edid_delay_ms);
+  print_monitor_mode(config->monitor_mode);
   print_physical_address(config->physical_address);
   print_logical_address(config->logical_address);
+
   const char *type = "unknown";
   switch ((cec_config_device_type_t)config->device_type) {
     case CEC_CONFIG_DEVICE_TYPE_TV:
@@ -220,6 +243,7 @@ static int exec_show(void *arg, int argc, const char **argv) {
         }
       }
     } else if (strcmp(argv[1], "cec") == 0) {
+      print_monitor_mode(cec_frame_get_monitor_mode());
       print_physical_address(cec_get_physical_address());
       print_logical_address(cec_get_logical_address());
     } else if (strcmp(argv[1], "version") == 0) {
@@ -305,6 +329,19 @@ static int exec_set(void *arg, int argc, const char **argv) {
           cdc_printfln("Unknown device type \'%s\'", argv[3]);
           return -1;
         }
+      } else if (strcmp(argv[2], "monitor_mode") == 0) {
+        if (strcmp(argv[3], "on") == 0) {
+          config.monitor_mode = 1;
+          print_monitor_mode(config.monitor_mode);
+          return 0;
+        } else if (strcmp(argv[3], "off") == 0) {
+          config.monitor_mode = 0;
+          print_monitor_mode(config.monitor_mode);
+          return 0;
+        } else {
+          cdc_printfln("Error parsing monitor mode");
+          return -1;
+        }
       }
     }
   } else if (argc == 3) {
@@ -329,10 +366,12 @@ static int exec_set(void *arg, int argc, const char **argv) {
 
 static const tclie_cmd_t cmds[] = {
     {"debug", exec_debug, "Control debug output.", "debug {on|off}"},
+    {"monitor", exec_monitor, "CEC bus monitor mode.", "monitor {on|off}"},
     {"query", exec_query, "Query information.", "query {edid}"},
     {"save", exec_save, "Save configuration.", "save"},
     {"set", exec_set, "Set configuration parameters.",
-     "set {(config (edid_delay_ms|logical_address|physical_address <value>)|(device_type "
+     "set {(config (edid_delay_ms|logical_address|physical_address|monitor_mode "
+     "<value>)|(device_type "
      "{playback|recording}))|(keymap <value>)}"},
     {"show", exec_show, "Show information.",
      "show {cec|config|keymap|nvs|(stats {cec|cpu|tasks})|version}"},


### PR DESCRIPTION
Allows the cec stack to silently listen on the bus thereby being able to function as a simple analyser.

Can be enabled in configuration parameters so as to never appear on the bus from startup.

Run time override available via console commands.

Preliminary testing conducted on rp2040 and esp32 targets.