### PR TITLE
Isolate pico-sdk specific header files

### DIFF
--- a/include/portable.h
+++ b/include/portable.h
@@ -1,0 +1,66 @@
+#ifndef _PORTABLE_H_
+#define _PORTABLE_H_
+
+#define DECLARE_TAG()
+
+//
+// Duplicate includes are commented out for compilation efficiency
+//
+
+// for blink.c
+#include "bsp/board.h"
+#include "pico/stdlib.h"
+
+// for cec-config.c
+#include "class/hid/hid.h"
+#include "tusb.h"
+
+// for cec-frame.c
+// #include "pico/stdlib.h"
+
+// for debug.c
+#include "hardware/timer.h"
+// #include "pico/stdlib.h"
+
+// for freertos_hook.c
+#include "common/tusb_common.h"
+
+// for cec-task.c
+// #include "class/hid/hid.h"
+// #include "pico/stdlib.h"
+// #include "tusb.h"
+
+// for ddc.c
+#include "hardware/i2c.h"
+// #include "pico/stdlib.h"
+
+// for main.c
+// #include "bsp/board.h"
+// #include "hardware/timer.h"
+// #include "pico/stdlib.h"
+
+// for nvs.c
+#include <hardware/flash.h>
+#include <hardware/sync.h>
+//// #include "crc/crc32.h"
+
+// for usb-cdc.c
+#include <hardware/watchdog.h>
+#include <pico/bootrom.h>
+// #include <tusb.h>
+
+// for usb_descriptors.c
+// #include "tusb.h"
+
+// for usb_hid.c
+// #include "bsp/board.h"
+// #include "pico/stdlib.h"
+// #include "tusb.h"
+
+// for ws2812.c
+#include "hardware/clocks.h"
+#include "hardware/pio.h"
+#include "pico/sem.h"
+// #include "pico/stdlib.h"
+
+#endif  // _PORTABLE_H_

--- a/src/blink.c
+++ b/src/blink.c
@@ -1,5 +1,5 @@
-#include "bsp/board.h"
-#include "pico/stdlib.h"
+#include "portable.h"
+DECLARE_TAG()
 
 #include "blink.h"
 #include "ws2812.h"

--- a/src/cec-config.c
+++ b/src/cec-config.c
@@ -1,5 +1,5 @@
-#include "class/hid/hid.h"
-#include "tusb.h"
+#include "portable.h"
+DECLARE_TAG()
 
 #include "cec-config.h"
 #include "cec-user.h"

--- a/src/cec-frame.c
+++ b/src/cec-frame.c
@@ -2,7 +2,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "pico/stdlib.h"
+#include "portable.h"
+DECLARE_TAG()
 
 #include "cec-frame.h"
 #include "cec-log.h"

--- a/src/cec-log.c
+++ b/src/cec-log.c
@@ -6,6 +6,9 @@
 #include "message_buffer.h"
 #include "task.h"
 
+#include "portable.h"
+DECLARE_TAG()
+
 #include "pico-cec/config.h"
 #include "pico-cec/util.h"
 

--- a/src/cec-task.c
+++ b/src/cec-task.c
@@ -2,9 +2,8 @@
 #include "queue.h"
 #include "task.h"
 
-#include "class/hid/hid.h"
-#include "pico/stdlib.h"
-#include "tusb.h"
+#include "portable.h"
+DECLARE_TAG()
 
 #include "blink.h"
 #include "cec-config.h"

--- a/src/ddc.c
+++ b/src/ddc.c
@@ -1,8 +1,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "hardware/i2c.h"
-#include "pico/stdlib.h"
+#include "portable.h"
+DECLARE_TAG()
 
 #include "cec-log.h"
 #include "ddc.h"

--- a/src/debug.c
+++ b/src/debug.c
@@ -4,8 +4,8 @@
 #include "queue.h"
 #include "task.h"
 
-#include "hardware/timer.h"
-#include "pico/stdlib.h"
+#include "portable.h"
+DECLARE_TAG()
 
 #include "cec-frame.h"
 #include "cec-task.h"

--- a/src/freertos_hook.c
+++ b/src/freertos_hook.c
@@ -29,7 +29,8 @@
 #include "FreeRTOS.h"
 #include "task.h"
 
-#include "common/tusb_common.h"
+#include "portable.h"
+DECLARE_TAG()
 
 #include "ws2812.h"
 

--- a/src/main.c
+++ b/src/main.c
@@ -2,8 +2,8 @@
 #include "queue.h"
 #include "task.h"
 
-#include "bsp/board.h"
-#include "pico/stdlib.h"
+#include "portable.h"
+DECLARE_TAG()
 
 #include "pico-cec/config.h"
 

--- a/src/nvs.c
+++ b/src/nvs.c
@@ -1,8 +1,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <hardware/flash.h>
-#include <hardware/sync.h>
+#include "portable.h"
+DECLARE_TAG()
 
 #include "crc/crc32.h"
 

--- a/src/usb-cdc.c
+++ b/src/usb-cdc.c
@@ -2,8 +2,8 @@
 #include <string.h>
 #include <tusb.h>
 
-#include <hardware/watchdog.h>
-#include <pico/bootrom.h>
+#include "portable.h"
+DECLARE_TAG()
 
 #include "pico-cec/config.h"
 #include "pico-cec/util.h"

--- a/src/usb_hid.c
+++ b/src/usb_hid.c
@@ -32,9 +32,8 @@
 #include "semphr.h"
 #include "task.h"
 
-#include "bsp/board.h"
-#include "pico/stdlib.h"
-#include "tusb.h"
+#include "portable.h"
+DECLARE_TAG()
 
 #include "usb_descriptors.h"
 #include "usb_hid.h"


### PR DESCRIPTION
Isolation of pico-sdk only include files from architecture independent common source modules is required to support ports to other devices.