### PR TITLE
Update blink.c to avoid build error

### DIFF
--- a/src/blink.c
+++ b/src/blink.c
@@ -13,8 +13,6 @@ void blink_init(void) {
   gpio_put(PICO_DEFAULT_WS2812_POWER_PIN, true);
 #endif
 #ifdef PICO_DEFAULT_WS2812_PIN
-#define WS2812_PIN PICO_DEFAULT_WS2812_PIN
-#else
 // default to pin 2 if the board doesn't have a default WS2812 pin defined
 #define PICO_DEFAULT_WS2812_PIN 2
 #endif

--- a/src/blink.c
+++ b/src/blink.c
@@ -12,7 +12,12 @@ void blink_init(void) {
   gpio_set_dir(PICO_DEFAULT_WS2812_POWER_PIN, GPIO_OUT);
   gpio_put(PICO_DEFAULT_WS2812_POWER_PIN, true);
 #endif
-
+#ifdef PICO_DEFAULT_WS2812_PIN
+#define WS2812_PIN PICO_DEFAULT_WS2812_PIN
+#else
+// default to pin 2 if the board doesn't have a default WS2812 pin defined
+#define PICO_DEFAULT_WS2812_PIN 2
+#endif
   // RGB = solid green on boot
   ws2812_init(PICO_DEFAULT_WS2812_PIN);
   ws2812_put_rgb(0, 0x78, 0);

--- a/src/blink.c
+++ b/src/blink.c
@@ -12,7 +12,7 @@ void blink_init(void) {
   gpio_set_dir(PICO_DEFAULT_WS2812_POWER_PIN, GPIO_OUT);
   gpio_put(PICO_DEFAULT_WS2812_POWER_PIN, true);
 #endif
-#ifdef PICO_DEFAULT_WS2812_PIN
+#ifndef PICO_DEFAULT_WS2812_PIN
 // default to pin 2 if the board doesn't have a default WS2812 pin defined
 #define PICO_DEFAULT_WS2812_PIN 2
 #endif


### PR DESCRIPTION
Building with -DPICO_BOARD=pico throw the following error: 
pico-cec/src/blink.c: In function 'blink_init':
pico-cec/src/blink.c:17:15: error: 'PICO_DEFAULT_WS2812_PIN' undeclared (first use in this function); did you mean 'PICO_DEFAULT_SPI_TX_PIN'?
   17 |   ws2812_init(PICO_DEFAULT_WS2812_PIN);
      |               ^~~~~~~~~~~~~~~~~~~~~~~
Added a default pin in case PICO_DEFAULT_WS2812_PIN is not defined