### PR TITLE
Add a 'send' CLI command.

### DIFF
--- a/include/cec-frame.h
+++ b/include/cec-frame.h
@@ -10,6 +10,10 @@
 
 extern TaskHandle_t xCECTask;
 
+#define NOTIFY_RX ((UBaseType_t)0)
+#define NOTIFY_TX ((UBaseType_t)1)
+#define NOTIFY_KICK ((UBaseType_t)2)
+
 typedef struct {
   uint8_t *data;
   uint8_t len;

--- a/include/cec-task.h
+++ b/include/cec-task.h
@@ -7,6 +7,7 @@
 
 uint16_t cec_get_physical_address(void);
 uint8_t cec_get_logical_address(void);
+bool cec_send_opcode(uint8_t opcode);
 void cec_task(void *param);
 
 #endif

--- a/src/cec-frame.c
+++ b/src/cec-frame.c
@@ -7,9 +7,6 @@
 #include "cec-frame.h"
 #include "cec-log.h"
 
-#define NOTIFY_RX ((UBaseType_t)0)
-#define NOTIFY_TX ((UBaseType_t)1)
-
 TaskHandle_t xCECTask;
 
 static uint8_t rx_buffer[16] = {0x0};
@@ -155,7 +152,15 @@ uint8_t cec_frame_recv(uint8_t *pld, uint8_t address) {
   rx_frame.ack = false;
   memset(&rx_frame.message->data[0], 0, 16);
   gpio_set_irq_enabled(CEC_PIN, GPIO_IRQ_EDGE_FALL, true);
-  ulTaskNotifyTakeIndexed(NOTIFY_RX, pdTRUE, portMAX_DELAY);
+
+  /* Wait for an RX notification, but wake early if a TX kick arrives. */
+  while (ulTaskNotifyTakeIndexed(NOTIFY_RX, pdTRUE, pdMS_TO_TICKS(50)) == 0) {
+    if (ulTaskNotifyTakeIndexed(NOTIFY_KICK, pdTRUE, 0) != 0) {
+      gpio_set_irq_enabled(CEC_PIN, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, false);
+      return 0;
+    }
+  }
+
   memcpy(pld, rx_frame.message->data, rx_frame.message->len);
   // printf("high water mark = %lu\n", uxTaskGetStackHighWaterMark(xCECTask));
 

--- a/src/cec-task.c
+++ b/src/cec-task.c
@@ -53,6 +53,12 @@ static uint16_t active_addr = 0x0000;
 /* Audio state. */
 static bool audio_status = false;
 
+/* Outbound TX queue: holds opcodes to be sent as broadcast frames. */
+#define CEC_TX_QUEUE_LEN 1
+static QueueHandle_t cec_tx_queue = NULL;
+static StaticQueue_t cec_tx_queue_buf;
+static uint8_t cec_tx_queue_storage[CEC_TX_QUEUE_LEN];
+
 /* Construct the frame address header. */
 #define HEADER0(iaddr, daddr) ((iaddr << 4) | daddr)
 
@@ -131,6 +137,17 @@ bool cec_ping(uint8_t destination) {
   return cec_frame_send(1, pld);
 }
 
+bool cec_send_opcode(uint8_t opcode) {
+  if (cec_tx_queue == NULL) {
+    return false;
+  }
+  if (xQueueSend(cec_tx_queue, &opcode, pdMS_TO_TICKS(10)) != pdTRUE) {
+    return false;
+  }
+  xTaskNotifyIndexed(xCECTask, NOTIFY_KICK, 0, eNoAction);
+  return true;
+}
+
 static void image_view_on(uint8_t initiator, uint8_t destination) {
   uint8_t pld[2] = {HEADER0(initiator, destination), CEC_ID_IMAGE_VIEW_ON};
 
@@ -192,6 +209,9 @@ void cec_task(void *param) {
   // load configuration
   nvs_load_config(&config);
 
+  cec_tx_queue = xQueueCreateStatic(CEC_TX_QUEUE_LEN, sizeof(uint8_t), cec_tx_queue_storage,
+                                    &cec_tx_queue_buf);
+
   // pause for EDID to settle
   vTaskDelay(pdMS_TO_TICKS(config.edid_delay_ms));
 
@@ -206,6 +226,12 @@ void cec_task(void *param) {
     uint8_t initiator, destination;
     uint8_t key = HID_KEY_NONE;
     uint8_t no_active = 0;
+
+    uint8_t tx_opcode;
+    if (xQueueReceive(cec_tx_queue, &tx_opcode, 0) == pdTRUE) {
+      uint8_t tx_pld[2] = {HEADER0(0x0f, 0x0f), tx_opcode};
+      cec_frame_send(2, tx_pld);
+    }
 
     pldcnt = cec_frame_recv(pld, laddr);
     // printf("pldcnt = %u\n", pldcnt);

--- a/src/usb-cdc.c
+++ b/src/usb-cdc.c
@@ -327,10 +327,26 @@ static int exec_set(void *arg, int argc, const char **argv) {
   return -1;
 }
 
+static int exec_send(void *arg, int argc, const char **argv) {
+  if (argc == 2) {
+    unsigned int opcode = 0;
+    if (sscanf(argv[1], "%x", &opcode) == 1 && opcode <= UINT8_MAX) {
+      if (cec_send_opcode((uint8_t)opcode)) {
+        return 0;
+      }
+      cdc_printfln("Send failed (queue full)");
+      return -1;
+    }
+    cdc_printfln("Error parsing opcode");
+  }
+  return -1;
+}
+
 static const tclie_cmd_t cmds[] = {
     {"debug", exec_debug, "Control debug output.", "debug {on|off}"},
     {"query", exec_query, "Query information.", "query {edid}"},
     {"save", exec_save, "Save configuration.", "save"},
+    {"send", exec_send, "Send a CEC opcode (broadcast).", "send <opcode>"},
     {"set", exec_set, "Set configuration parameters.",
      "set {(config (edid_delay_ms|logical_address|physical_address <value>)|(device_type "
      "{playback|recording}))|(keymap <value>)}"},


### PR DESCRIPTION
This allows me to turn on/off my TV by with a UART command.

Examples:

- send 4: set image view on (turn TV on)
- send 36: set standby (turn TV off)

---

Thanks for creating / sharing this project!

I built the hardware without understanding the firmware, knowing that I could change it later.

Turns out my usecase is entirely opposite of this project.  At the moment this project accepts HDMI CEC inputs to create HID outputs.  I have an HID input (standard mouse/keyboard) for my TV, and I want to have HDMI CEC outputs in response to HID inputs.  Specifically I want my TV to turn on with mouse/keyboard activity, and off with standby.