### PR TITLE
Refactor CEC frame handling.

### DIFF
--- a/include/cec-frame.h
+++ b/include/cec-frame.h
@@ -8,14 +8,30 @@
 #define CEC_PIN 3  // GPIO3 == D10 (Seeed Studio XIAO RP2040)
 #endif
 
+/* Maximum length of CEC frame in bytes. */
+#define CEC_FRAME_MAX_LEN (16)
+
+/* Maximum length of CEC frame operand in bytes. */
+#define CEC_FRAME_MAX_OPERAND_LEN (CEC_FRAME_MAX_LEN - 2)
+
 extern TaskHandle_t xCECTask;
 
 #define NOTIFY_RX ((UBaseType_t)0)
 #define NOTIFY_TX ((UBaseType_t)1)
-#define NOTIFY_KICK ((UBaseType_t)2)
 
-typedef struct {
-  uint8_t *data;
+#define NOTIFY_RX_RX (1UL << 0)
+#define NOTIFY_RX_ABORT (1UL << 1)
+#define NOTIFY_RX_TX (1UL << 2)
+
+typedef struct __attribute__((packed)) {
+  union {
+    struct {
+      uint8_t header;
+      uint8_t opcode;
+      uint8_t operand[CEC_FRAME_MAX_OPERAND_LEN];
+    };
+    uint8_t data[CEC_FRAME_MAX_LEN];
+  };
   uint8_t len;
 } cec_message_t;
 
@@ -56,7 +72,7 @@ typedef struct {
 
 void cec_frame_init(void);
 void cec_frame_get_stats(cec_frame_stats_t *stats);
-bool cec_frame_send(uint8_t pldcnt, uint8_t *pld);
-uint8_t cec_frame_recv(uint8_t *pld, uint8_t address);
+bool cec_frame_send(const cec_message_t *message);
+void cec_frame_recv(cec_message_t *message, uint8_t address);
 
 #endif

--- a/include/cec-task.h
+++ b/include/cec-task.h
@@ -7,7 +7,7 @@
 
 uint16_t cec_get_physical_address(void);
 uint8_t cec_get_logical_address(void);
-bool cec_send_opcode(uint8_t opcode);
+bool cec_send_msg(uint8_t address, uint8_t opcode);
 void cec_task(void *param);
 
 #endif

--- a/src/cec-frame.c
+++ b/src/cec-frame.c
@@ -9,8 +9,7 @@
 
 TaskHandle_t xCECTask;
 
-static uint8_t rx_buffer[16] = {0x0};
-static cec_message_t rx_message = {.data = &rx_buffer[0], .len = 0};
+static cec_message_t rx_message = {.data = {0x0}, .len = 0};
 static cec_frame_t rx_frame = {.message = &rx_message};
 
 /* CEC statistics. */
@@ -53,7 +52,7 @@ static void frame_rx_isr(uint gpio, uint32_t events) {
         gpio_set_irq_enabled(CEC_PIN, GPIO_IRQ_EDGE_FALL, true);
       } else {
         rx_frame.state = CEC_FRAME_STATE_ABORT;
-        xTaskNotifyIndexedFromISR(xCECTask, NOTIFY_RX, 0, eNoAction, NULL);
+        xTaskNotifyIndexedFromISR(xCECTask, NOTIFY_RX, NOTIFY_RX_ABORT, eSetBits, NULL);
       }
       return;
     case CEC_FRAME_STATE_EOM_LOW:
@@ -74,7 +73,7 @@ static void frame_rx_isr(uint gpio, uint32_t events) {
         gpio_set_irq_enabled(CEC_PIN, GPIO_IRQ_EDGE_RISE, true);
       } else {
         rx_frame.state = CEC_FRAME_STATE_ABORT;
-        xTaskNotifyIndexedFromISR(xCECTask, NOTIFY_RX, 0, eNoAction, NULL);
+        xTaskNotifyIndexedFromISR(xCECTask, NOTIFY_RX, NOTIFY_RX_ABORT, eSetBits, NULL);
       }
     }
       return;
@@ -88,7 +87,7 @@ static void frame_rx_isr(uint gpio, uint32_t events) {
         bit = false;
       } else {
         rx_frame.state = CEC_FRAME_STATE_ABORT;
-        xTaskNotifyIndexedFromISR(xCECTask, NOTIFY_RX, 0, eNoAction, NULL);
+        xTaskNotifyIndexedFromISR(xCECTask, NOTIFY_RX, NOTIFY_RX_ABORT, eSetBits, NULL);
         return;
       }
       if (rx_frame.state == CEC_FRAME_STATE_EOM_HIGH) {
@@ -125,7 +124,7 @@ static void frame_rx_isr(uint gpio, uint32_t events) {
         rx_frame.state = CEC_FRAME_STATE_ACK_END;
       } else {
         rx_frame.state = CEC_FRAME_STATE_ABORT;
-        xTaskNotifyIndexedFromISR(xCECTask, NOTIFY_RX, 0, eNoAction, NULL);
+        xTaskNotifyIndexedFromISR(xCECTask, NOTIFY_RX, NOTIFY_RX_ABORT, eSetBits, NULL);
         return;
       }
       // fall through
@@ -141,39 +140,41 @@ static void frame_rx_isr(uint gpio, uint32_t events) {
     case CEC_FRAME_STATE_END:
     default:
       rx_frame.message->len = rx_frame.byte;
-      xTaskNotifyIndexedFromISR(xCECTask, NOTIFY_RX, 0, eNoAction, NULL);
+      xTaskNotifyIndexedFromISR(xCECTask, NOTIFY_RX, NOTIFY_RX_RX, eSetBits, NULL);
   }
 }
 
-uint8_t cec_frame_recv(uint8_t *pld, uint8_t address) {
+void cec_frame_recv(cec_message_t *message, uint8_t address) {
   // printf("cec_frame_recv\n");
   rx_frame.address = address;
   rx_frame.state = CEC_FRAME_STATE_START_LOW;
   rx_frame.ack = false;
-  memset(&rx_frame.message->data[0], 0, 16);
+  memset(&rx_frame.message->data[0], 0, CEC_FRAME_MAX_LEN);
   gpio_set_irq_enabled(CEC_PIN, GPIO_IRQ_EDGE_FALL, true);
 
-  /* Wait for an RX notification, but wake early if a TX kick arrives. */
-  while (ulTaskNotifyTakeIndexed(NOTIFY_RX, pdTRUE, pdMS_TO_TICKS(50)) == 0) {
-    if (ulTaskNotifyTakeIndexed(NOTIFY_KICK, pdTRUE, 0) != 0) {
-      gpio_set_irq_enabled(CEC_PIN, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, false);
-      return 0;
-    }
-  }
+  uint32_t notify = 0;
 
-  memcpy(pld, rx_frame.message->data, rx_frame.message->len);
-  // printf("high water mark = %lu\n", uxTaskGetStackHighWaterMark(xCECTask));
+  /* Wait for an RX notification: RX_RX (default), RX_ABORT or RX_TX */
+  xTaskNotifyWaitIndexed(NOTIFY_RX, 0x00, 0xffffffff, &notify, portMAX_DELAY);
 
-  cec_log_frame(&rx_frame, true);
-
-  if (rx_frame.state == CEC_FRAME_STATE_ABORT) {
+  if (notify == NOTIFY_RX_TX) {
+    gpio_set_irq_enabled(CEC_PIN, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, false);
+    return;
+  } else if (notify == NOTIFY_RX_ABORT) {
     // printf("ABORT\n");
     cec_stats.rx_abort_frames++;
-    return 0;
+    message->len = 0;
+    return;
   }
 
+  memcpy(message, rx_frame.message, rx_frame.message->len);
+  // printf("high water mark = %lu\n", uxTaskGetStackHighWaterMark(xCECTask));
+
+  message->len = rx_frame.message->len;
+  cec_log_frame(&rx_frame, true);
+
   cec_stats.rx_frames++;
-  return rx_frame.message->len;
+  return;
 }
 
 static int64_t frame_tx_callback(alarm_id_t alarm, void *user_data) {
@@ -245,7 +246,7 @@ static int64_t frame_tx_callback(alarm_id_t alarm, void *user_data) {
   }
 }
 
-static bool frame_tx(uint8_t *data, uint8_t len) {
+static bool frame_tx(const cec_message_t *message) {
   unsigned char i = 0;
 
   // wait 7 bit times of idle before sending
@@ -259,8 +260,7 @@ static bool frame_tx(uint8_t *data, uint8_t len) {
     }
   }
 
-  cec_message_t message = {data, len};
-  cec_frame_t frame = {.message = &message,
+  cec_frame_t frame = {.message = (cec_message_t *)message,
                        .bit = 7,
                        .byte = 0,
                        .start = 0,
@@ -280,10 +280,10 @@ static bool frame_tx(uint8_t *data, uint8_t len) {
   return frame.ack;
 }
 
-bool cec_frame_send(uint8_t pldcnt, uint8_t *pld) {
+bool cec_frame_send(const cec_message_t *message) {
   // disable GPIO ISR for sending
   gpio_set_irq_enabled(CEC_PIN, GPIO_IRQ_EDGE_RISE | GPIO_IRQ_EDGE_FALL, false);
-  return frame_tx(pld, pldcnt);
+  return frame_tx(message);
 }
 
 void cec_frame_get_stats(cec_frame_stats_t *stats) {

--- a/src/cec-task.c
+++ b/src/cec-task.c
@@ -18,11 +18,18 @@
 /* Intercept HDMI CEC commands, convert to a keypress and send to HID task
  * handler.
  *
- * Based (mostly ripped) from the Arduino version by Szymon Slupik:
+ * Significantly rewritten from the initial Arduino version by Szymon Slupik:
  * https://github.com/SzymonSlupik/CEC-Tiny-Pro
  * which itself is based on the original code by Thomas Sowell:
  * https://github.com/tsowell/avr-hdmi-cec-volume/tree/master
  */
+
+#define CEC_MSG_QUEUE_LENGTH (8)
+
+typedef struct {
+  uint8_t addr;
+  cec_id_t id;
+} send_msg_t;
 
 /** The running CEC configuration. */
 static cec_config_t config = {0x0};
@@ -66,106 +73,160 @@ static void cec_feature_abort(uint8_t initiator,
                               uint8_t destination,
                               uint8_t msg,
                               cec_abort_t reason) {
-  uint8_t pld[4] = {HEADER0(initiator, destination), CEC_ID_FEATURE_ABORT, msg, reason};
+  cec_message_t message = {
+      .header = HEADER0(initiator, destination),
+      .opcode = CEC_ID_FEATURE_ABORT,
+      .operand = {msg, reason},
+      .len = 4,
+  };
 
-  cec_frame_send(4, pld);
+  cec_frame_send(&message);
 }
 
 static void device_vendor_id(uint8_t initiator, uint8_t destination, uint32_t vendor_id) {
-  uint8_t pld[5] = {HEADER0(initiator, destination), CEC_ID_DEVICE_VENDOR_ID,
-                    (vendor_id >> 16) & 0x0ff, (vendor_id >> 8) & 0x0ff, (vendor_id >> 0) & 0x0ff};
+  cec_message_t message = {
+      .header = HEADER0(initiator, destination),
+      .opcode = CEC_ID_DEVICE_VENDOR_ID,
+      .operand = {(vendor_id >> 16) & 0x0ff, (vendor_id >> 8) & 0x0ff, (vendor_id >> 0) & 0x0ff},
+      .len = 5,
+  };
 
-  cec_frame_send(5, pld);
+  cec_frame_send(&message);
 }
 
 static void report_power_status(uint8_t initiator, uint8_t destination, uint8_t power_status) {
-  uint8_t pld[3] = {HEADER0(initiator, destination), CEC_ID_REPORT_POWER_STATUS, power_status};
+  cec_message_t message = {.header = HEADER0(initiator, destination),
+                           .opcode = CEC_ID_REPORT_POWER_STATUS,
+                           .operand = {power_status},
+                           .len = 3};
 
-  cec_frame_send(3, pld);
+  cec_frame_send(&message);
 }
 
 static void set_system_audio_mode(uint8_t initiator,
                                   uint8_t destination,
                                   uint8_t system_audio_mode) {
-  uint8_t pld[3] = {HEADER0(initiator, destination), CEC_ID_SET_SYSTEM_AUDIO_MODE,
-                    system_audio_mode};
+  cec_message_t message = {
+      .header = HEADER0(initiator, destination),
+      .opcode = CEC_ID_SET_SYSTEM_AUDIO_MODE,
+      .operand = {system_audio_mode},
+      .len = 3,
+  };
 
-  cec_frame_send(3, pld);
+  cec_frame_send(&message);
 }
 
 static void report_audio_status(uint8_t initiator, uint8_t destination, uint8_t audio_status) {
-  uint8_t pld[3] = {HEADER0(initiator, destination), CEC_ID_REPORT_AUDIO_STATUS, audio_status};
+  cec_message_t message = {.header = HEADER0(initiator, destination),
+                           .opcode = CEC_ID_REPORT_AUDIO_STATUS,
+                           .operand = {audio_status},
+                           .len = 3};
 
-  cec_frame_send(3, pld);
+  cec_frame_send(&message);
 }
 
 static void system_audio_mode_status(uint8_t initiator,
                                      uint8_t destination,
                                      uint8_t system_audio_mode_status) {
-  uint8_t pld[3] = {HEADER0(initiator, destination), CEC_ID_SYSTEM_AUDIO_MODE_STATUS,
-                    system_audio_mode_status};
+  cec_message_t message = {
+      .header = HEADER0(initiator, destination),
+      .opcode = CEC_ID_SYSTEM_AUDIO_MODE_STATUS,
+      .operand = {system_audio_mode_status},
+      .len = 3,
+  };
 
-  cec_frame_send(3, pld);
+  cec_frame_send(&message);
 }
 
 static void set_osd_name(uint8_t initiator, uint8_t destination) {
-  uint8_t pld[10] = {
-      HEADER0(initiator, destination), CEC_ID_SET_OSD_NAME, 'P', 'i', 'c', 'o', '-', 'C', 'E', 'C'};
+  cec_message_t message = {
+      .header = HEADER0(initiator, destination),
+      .opcode = CEC_ID_SET_OSD_NAME,
+      .operand = {'P', 'i', 'c', 'o', '-', 'C', 'E', 'C'},
+      .len = 10,
+  };
 
-  cec_frame_send(10, pld);
+  cec_frame_send(&message);
 }
 
 static void report_physical_address(uint8_t initiator,
                                     uint8_t destination,
                                     uint16_t physical_address,
                                     uint8_t device_type) {
-  uint8_t pld[5] = {HEADER0(initiator, destination), CEC_ID_REPORT_PHYSICAL_ADDRESS,
-                    (physical_address >> 8) & 0x0ff, (physical_address >> 0) & 0x0ff, device_type};
+  cec_message_t message = {
+      .header = HEADER0(initiator, destination),
+      .opcode = CEC_ID_REPORT_PHYSICAL_ADDRESS,
+      .operand = {(physical_address >> 8) & 0x0ff, (physical_address >> 0) & 0x0ff, device_type},
+      .len = 5,
+  };
 
-  cec_frame_send(5, pld);
+  cec_frame_send(&message);
 }
 
 static void report_cec_version(uint8_t initiator, uint8_t destination) {
-  // 0x04 = 1.3a
-  uint8_t pld[3] = {HEADER0(initiator, destination), CEC_ID_CEC_VERSION, 0x04};
-  cec_frame_send(3, pld);
+  cec_message_t message = {
+      .header = HEADER0(initiator, destination),
+      .opcode = CEC_ID_CEC_VERSION,
+      .operand = {0x04},  // 0x04 = 1.3a
+      .len = 3,
+  };
+
+  cec_frame_send(&message);
 }
 
 bool cec_ping(uint8_t destination) {
-  uint8_t pld[1] = {HEADER0(destination, destination)};
-
-  return cec_frame_send(1, pld);
+  cec_message_t message = {
+      .header = HEADER0(destination, destination),
+      .len = 1,
+  };
+  return cec_frame_send(&message);
 }
 
-bool cec_send_opcode(uint8_t opcode) {
+bool cec_send_msg(uint8_t address, uint8_t opcode) {
+  send_msg_t msg = {.addr = address, .id = opcode};
+
   if (cec_tx_queue == NULL) {
     return false;
   }
-  if (xQueueSend(cec_tx_queue, &opcode, pdMS_TO_TICKS(10)) != pdTRUE) {
+
+  if (xQueueSend(cec_tx_queue, &msg, pdMS_TO_TICKS(10)) != pdTRUE) {
     return false;
   }
-  xTaskNotifyIndexed(xCECTask, NOTIFY_KICK, 0, eNoAction);
+  xTaskNotifyIndexed(xCECTask, NOTIFY_RX, NOTIFY_RX_TX, eSetBits);
   return true;
 }
 
 static void image_view_on(uint8_t initiator, uint8_t destination) {
-  uint8_t pld[2] = {HEADER0(initiator, destination), CEC_ID_IMAGE_VIEW_ON};
+  cec_message_t message = {
+      .header = HEADER0(initiator, destination),
+      .opcode = CEC_ID_IMAGE_VIEW_ON,
+      .len = 2,
+  };
 
-  cec_frame_send(2, pld);
+  cec_frame_send(&message);
 }
 
 static void active_source(uint8_t initiator, uint16_t physical_address) {
-  uint8_t pld[4] = {HEADER0(initiator, 0x0f), CEC_ID_ACTIVE_SOURCE, (physical_address >> 8) & 0x0ff,
-                    (physical_address >> 0) & 0x0ff};
+  cec_message_t message = {
+      .header = HEADER0(initiator, 0x0f),
+      .opcode = CEC_ID_ACTIVE_SOURCE,
+      .operand = {(physical_address >> 8) & 0x0ff, (physical_address >> 0) & 0x0ff},
+      .len = 4,
+  };
 
-  cec_frame_send(4, pld);
+  cec_frame_send(&message);
 }
 
 static void menu_status(uint8_t initiator, uint8_t destination, bool menu_state) {
   uint8_t state = menu_state ? (uint8_t)CEC_MENU_ACTIVATE : (uint8_t)CEC_MENU_DEACTIVATE;
-  uint8_t pld[3] = {HEADER0(initiator, destination), CEC_ID_MENU_STATUS, state};
+  cec_message_t message = {
+      .header = HEADER0(initiator, destination),
+      .opcode = CEC_ID_MENU_STATUS,
+      .operand = {state},
+      .len = 3,
+  };
 
-  cec_frame_send(sizeof(pld), pld);
+  cec_frame_send(&message);
 }
 
 static uint8_t allocate_logical_address(cec_config_t *config) {
@@ -221,25 +282,28 @@ void cec_task(void *param) {
   laddr = allocate_logical_address(&config);
 
   while (true) {
-    uint8_t pld[16] = {0x0};
-    uint8_t pldcnt;
-    uint8_t initiator, destination;
+    cec_message_t msg = {0x0};
     uint8_t key = HID_KEY_NONE;
     uint8_t no_active = 0;
 
-    uint8_t tx_opcode;
-    if (xQueueReceive(cec_tx_queue, &tx_opcode, 0) == pdTRUE) {
-      uint8_t tx_pld[2] = {HEADER0(laddr, 0x00), tx_opcode};
-      cec_frame_send(2, tx_pld);
+    cec_frame_recv(&msg, laddr);
+
+    send_msg_t tx_req;
+    if (xQueueReceive(cec_tx_queue, &tx_req, 0) == pdTRUE) {
+      cec_message_t tx_msg = {
+          .header = HEADER0(laddr, tx_req.addr),
+          .opcode = tx_req.id,
+          .len = 2,
+      };
+      cec_frame_send(&tx_msg);
+      continue;
     }
 
-    pldcnt = cec_frame_recv(pld, laddr);
-    // printf("pldcnt = %u\n", pldcnt);
-    initiator = (pld[0] & 0xf0) >> 4;
-    destination = pld[0] & 0x0f;
+    if (msg.len > 1) {
+      uint8_t initiator = (msg.header & 0xf0) >> 4;
+      uint8_t destination = msg.header & 0x0f;
 
-    if ((pldcnt > 1)) {
-      switch (pld[1]) {
+      switch (msg.opcode) {
         case CEC_ID_IMAGE_VIEW_ON:
           break;
         case CEC_ID_TEXT_VIEW_ON:
@@ -262,7 +326,7 @@ void cec_task(void *param) {
           break;
         case CEC_ID_SET_SYSTEM_AUDIO_MODE:
           if (destination == laddr || destination == 0x0f) {
-            audio_status = (pld[2] == 1);
+            audio_status = (msg.operand[0] == 1);
           }
           break;
         case CEC_ID_GIVE_SYSTEM_AUDIO_MODE_STATUS:
@@ -272,8 +336,7 @@ void cec_task(void *param) {
         case CEC_ID_SYSTEM_AUDIO_MODE_STATUS:
           break;
         case CEC_ID_ROUTING_CHANGE:
-          // uint16_t old_addr = (pld[2] << 8) | pld[3];
-          active_addr = (pld[4] << 8) | pld[5];
+          active_addr = (msg.operand[2] << 8) | msg.operand[3];
           paddr = get_physical_address(&config);
           laddr = allocate_logical_address(&config);
           if (paddr == active_addr) {
@@ -283,7 +346,7 @@ void cec_task(void *param) {
           }
           break;
         case CEC_ID_ACTIVE_SOURCE:
-          active_addr = (pld[2] << 8) | pld[3];
+          active_addr = (msg.operand[0] << 8) | msg.operand[1];
           no_active = 0;
           break;
         case CEC_ID_REPORT_PHYSICAL_ADDRESS:
@@ -305,7 +368,7 @@ void cec_task(void *param) {
           }
           break;
         case CEC_ID_SET_STREAM_PATH:
-          if (paddr == ((pld[2] << 8) | pld[3])) {
+          if (paddr == ((msg.operand[0] << 8) | msg.operand[1])) {
             active_addr = paddr;
             image_view_on(laddr, 0x00);
             active_source(laddr, paddr);
@@ -329,7 +392,7 @@ void cec_task(void *param) {
           break;
         case CEC_ID_MENU_REQUEST:
           if (destination == laddr) {
-            cec_menu_t request = (uint8_t)pld[2];
+            cec_menu_t request = msg.operand[0];
             switch (request) {
               case CEC_MENU_ACTIVATE:
                 menu_state = true;
@@ -378,7 +441,7 @@ void cec_task(void *param) {
         case CEC_ID_USER_CONTROL_PRESSED:
           if (destination == laddr) {
             blink_set(BLINK_STATE_GREEN_ON);
-            command_t command = config.keymap[pld[2]];
+            command_t command = config.keymap[msg.operand[0]];
             if (command.name != NULL) {
               xQueueSend(*q, &command.key, pdMS_TO_TICKS(10));
             }
@@ -393,7 +456,7 @@ void cec_task(void *param) {
           break;
         case CEC_ID_ABORT:
           if (destination == laddr) {
-            cec_feature_abort(laddr, initiator, pld[1], CEC_ABORT_REFUSED);
+            cec_feature_abort(laddr, initiator, msg.opcode, CEC_ABORT_REFUSED);
           }
           break;
         case CEC_ID_FEATURE_ABORT:
@@ -402,7 +465,7 @@ void cec_task(void *param) {
           break;
         default:
           if (destination == laddr) {
-            cec_feature_abort(laddr, initiator, pld[1], CEC_ABORT_UNRECOGNIZED);
+            cec_feature_abort(laddr, initiator, msg.opcode, CEC_ABORT_UNRECOGNIZED);
           }
           break;
       }

--- a/src/ddc.c
+++ b/src/ddc.c
@@ -41,13 +41,13 @@ static int verify(uint8_t *edid, size_t len) {
   // log the data
   if ((len % 8) == 0) {
     for (size_t i = 0; i < len; i += 8) {
-      cec_log_submitf("[%d] %02x %02x %02x %02x %02x %02x %02x %02x"_LOG_BR, i, edid[i],
+      cec_log_submitf("[%d] %02x %02x %02x %02x %02x %02x %02x %02x" _LOG_BR, i, edid[i],
                       edid[i + 1], edid[i + 2], edid[i + 3], edid[i + 4], edid[i + 5], edid[i + 6],
                       edid[i + 7]);
     }
   } else {
     for (size_t i = 0; i < len; i++) {
-      cec_log_submitf("[%d] %02x"_LOG_BR, i, edid[i]);
+      cec_log_submitf("[%d] %02x" _LOG_BR, i, edid[i]);
     }
   }
 
@@ -65,16 +65,16 @@ static int verify(uint8_t *edid, size_t len) {
 static int read_edid_block(uint8_t *edid, size_t len) {
   int ret = i2c_read_timeout_us(i2c_default, EDID_I2C_ADDR, edid, len, false, EDID_I2C_TIMEOUT_US);
   if (ret != len) {
-    cec_log_submitf("Failed to read %d bytes from 0x%02x"_LOG_BR, len, EDID_I2C_ADDR);
+    cec_log_submitf("Failed to read %d bytes from 0x%02x" _LOG_BR, len, EDID_I2C_ADDR);
     return PICO_ERROR_GENERIC;
   }
 
   if (verify(edid, len)) {
-    cec_log_submitf("Failed to verify EDID block checksum"_LOG_BR);
+    cec_log_submitf("Failed to verify EDID block checksum" _LOG_BR);
     return PICO_ERROR_GENERIC;
   }
 
-  cec_log_submitf("Read %d bytes from 0x%02x"_LOG_BR, ret, EDID_I2C_ADDR);
+  cec_log_submitf("Read %d bytes from 0x%02x" _LOG_BR, ret, EDID_I2C_ADDR);
 
   return PICO_ERROR_NONE;
 }
@@ -94,7 +94,7 @@ static uint16_t find_physical_address(uint8_t *block, size_t len) {
   if (memcmp(&block[1], vsbhdr, 3) == 0) {
     // HDMI Licensing, LLC block
     uint16_t addr = (block[4] << 8) | block[3];
-    cec_log_submitf("  physical address = %04x"_LOG_BR, addr);
+    cec_log_submitf("  physical address = %04x" _LOG_BR, addr);
     return addr;
   }
 
@@ -113,23 +113,23 @@ static uint16_t get_physical_address(void) {
     return 0x0000;
   }
 
-  cec_log_submitf(" EDID header"_LOG_BR);
+  cec_log_submitf(" EDID header" _LOG_BR);
   if (edid[126] == 0x00) {
-    cec_log_submitf("Missing CTA extensions"_LOG_BR);
+    cec_log_submitf("Missing CTA extensions" _LOG_BR);
     return 0x0000;
   }
 
   uint8_t *cta = &edid[EDID_BLOCK_SIZE];
   if (memcmp(cta, ctahdr, 2) == 0) {
     // Valid CTA extension block
-    cec_log_submitf(" CTA Extension"_LOG_BR);
-    cec_log_submitf("    DTD start: 0x%02x"_LOG_BR, cta[EDID_CTA_DTD_START]);
+    cec_log_submitf(" CTA Extension" _LOG_BR);
+    cec_log_submitf("    DTD start: 0x%02x" _LOG_BR, cta[EDID_CTA_DTD_START]);
 
     uint8_t offset = EDID_CTA_DBC_OFFSET;
     for (uint8_t i = offset; i < cta[EDID_CTA_DTD_START];) {
       uint8_t *db = &cta[i];
       uint8_t len = (db[0] & 0x1f);
-      cec_log_submitf("  [%u](%u) data block: %02x"_LOG_BR, i, len, db[0]);
+      cec_log_submitf("  [%u](%u) data block: %02x" _LOG_BR, i, len, db[0]);
       if (len == 0x00) {
         i++;
         continue;
@@ -153,11 +153,11 @@ uint16_t ddc_get_physical_address(void) {
 
   ddc_init();
 
-  cec_log_submitf("%s"_LOG_BR, "Issuing DDC reset");
+  cec_log_submitf("%s" _LOG_BR, "Issuing DDC reset");
   // issue a DDC reset
   int ret = i2c_write_timeout_us(i2c_default, EDID_I2C_ADDR, &zero, 1, true, EDID_I2C_TIMEOUT_US);
   if (ret != 1) {
-    cec_log_submitf("Failed to write DDC reset: %s"_LOG_BR,
+    cec_log_submitf("Failed to write DDC reset: %s" _LOG_BR,
                     ret == PICO_ERROR_TIMEOUT ? "timeout" : "generic");
     return 0x0000;
   }

--- a/src/usb-cdc.c
+++ b/src/usb-cdc.c
@@ -328,10 +328,12 @@ static int exec_set(void *arg, int argc, const char **argv) {
 }
 
 static int exec_send(void *arg, int argc, const char **argv) {
-  if (argc == 2) {
+  if (argc == 3) {
+    unsigned int address = 0;
     unsigned int opcode = 0;
-    if (sscanf(argv[1], "%x", &opcode) == 1 && opcode <= UINT8_MAX) {
-      if (cec_send_opcode((uint8_t)opcode)) {
+    if (sscanf(argv[1], "%x", &address) == 1 && address <= 0x0f
+        && sscanf(argv[2], "%x", &opcode) == 1 && opcode <= UINT8_MAX) {
+      if (cec_send_msg((uint8_t)address, (uint8_t)opcode)) {
         return 0;
       }
       cdc_printfln("Send failed (queue full)");
@@ -346,7 +348,7 @@ static const tclie_cmd_t cmds[] = {
     {"debug", exec_debug, "Control debug output.", "debug {on|off}"},
     {"query", exec_query, "Query information.", "query {edid}"},
     {"save", exec_save, "Save configuration.", "save"},
-    {"send", exec_send, "Send a CEC opcode (broadcast).", "send <opcode>"},
+    {"send", exec_send, "Send a CEC opcode.", "send <addr> <opcode>"},
     {"set", exec_set, "Set configuration parameters.",
      "set {(config (edid_delay_ms|logical_address|physical_address <value>)|(device_type "
      "{playback|recording}))|(keymap <value>)}"},
@@ -387,9 +389,9 @@ void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts) {
 
   if (dtr) {
     // Terminal connected
-    tud_cdc_write_str("Connected"_CDC_BR);
+    tud_cdc_write_str("Connected" _CDC_BR);
   } else {
     // Terminal disconnected
-    tud_cdc_write_str("Disconnected"_CDC_BR);
+    tud_cdc_write_str("Disconnected" _CDC_BR);
   }
 }


### PR DESCRIPTION
Use message structs for passing CEC frames around. Extend the `send` command to require target address.

Also, refactor and simplify the RX task 'kick' to use single task notification as event group.
During testing I found significant latency and missed CEC frame reception.
This change ensures the RX task will always immediately respond to either an RX event or send TX request event.