### PR TITLE
rewrite `exec_send` to allow for additional operands

### DIFF
--- a/include/cec-frame.h
+++ b/include/cec-frame.h
@@ -23,6 +23,9 @@ extern TaskHandle_t xCECTask;
 #define NOTIFY_RX_ABORT (1UL << 1)
 #define NOTIFY_RX_TX (1UL << 2)
 
+/* Construct the frame address header. */
+#define HEADER0(iaddr, daddr) ((iaddr << 4) | daddr)
+
 typedef struct __attribute__((packed)) {
   union {
     struct {

--- a/include/cec-task.h
+++ b/include/cec-task.h
@@ -2,12 +2,13 @@
 #define CEC_TASK_H
 
 #include <stdint.h>
+#include "cec-frame.h"
 
 #define CEC_TASK_NAME "cec"
 
 uint16_t cec_get_physical_address(void);
 uint8_t cec_get_logical_address(void);
-bool cec_send_msg(uint8_t address, uint8_t opcode);
+bool cec_send_msg(const cec_message_t *msg);
 void cec_task(void *param);
 
 #endif

--- a/src/cec-task.c
+++ b/src/cec-task.c
@@ -26,11 +26,6 @@
 
 #define CEC_MSG_QUEUE_LENGTH (8)
 
-typedef struct {
-  uint8_t addr;
-  cec_id_t id;
-} send_msg_t;
-
 /** The running CEC configuration. */
 static cec_config_t config = {0x0};
 
@@ -60,14 +55,11 @@ static uint16_t active_addr = 0x0000;
 /* Audio state. */
 static bool audio_status = false;
 
-/* Outbound TX queue: holds opcodes to be sent as broadcast frames. */
+/* Outbound TX queue: holds CEC messages to be sent. */
 #define CEC_TX_QUEUE_LEN 1
 static QueueHandle_t cec_tx_queue = NULL;
 static StaticQueue_t cec_tx_queue_buf;
-static uint8_t cec_tx_queue_storage[CEC_TX_QUEUE_LEN * sizeof(send_msg_t)];
-
-/* Construct the frame address header. */
-#define HEADER0(iaddr, daddr) ((iaddr << 4) | daddr)
+static uint8_t cec_tx_queue_storage[CEC_TX_QUEUE_LEN * sizeof(cec_message_t)];
 
 static void cec_feature_abort(uint8_t initiator,
                               uint8_t destination,
@@ -186,14 +178,12 @@ bool cec_ping(uint8_t destination) {
   return cec_frame_send(&message);
 }
 
-bool cec_send_msg(uint8_t address, uint8_t opcode) {
-  send_msg_t msg = {.addr = address, .id = opcode};
-
+bool cec_send_msg(const cec_message_t *msg) {
   if (cec_tx_queue == NULL) {
     return false;
   }
 
-  if (xQueueSend(cec_tx_queue, &msg, pdMS_TO_TICKS(10)) != pdTRUE) {
+  if (xQueueSend(cec_tx_queue, msg, pdMS_TO_TICKS(10)) != pdTRUE) {
     return false;
   }
   xTaskNotifyIndexed(xCECTask, NOTIFY_RX, NOTIFY_RX_TX, eSetBits);
@@ -274,7 +264,7 @@ void cec_task(void *param) {
   // load configuration
   nvs_load_config(&config);
 
-  cec_tx_queue = xQueueCreateStatic(CEC_TX_QUEUE_LEN, sizeof(send_msg_t), cec_tx_queue_storage,
+  cec_tx_queue = xQueueCreateStatic(CEC_TX_QUEUE_LEN, sizeof(cec_message_t), cec_tx_queue_storage,
                                     &cec_tx_queue_buf);
 
   // pause for EDID to settle
@@ -292,13 +282,8 @@ void cec_task(void *param) {
 
     cec_frame_recv(&msg, laddr);
 
-    send_msg_t tx_req;
-    if (xQueueReceive(cec_tx_queue, &tx_req, 0) == pdTRUE) {
-      cec_message_t tx_msg = {
-          .header = HEADER0(laddr, tx_req.addr),
-          .opcode = tx_req.id,
-          .len = 2,
-      };
+    cec_message_t tx_msg;
+    if (xQueueReceive(cec_tx_queue, &tx_msg, 0) == pdTRUE) {
       cec_frame_send(&tx_msg);
       continue;
     }

--- a/src/usb-cdc.c
+++ b/src/usb-cdc.c
@@ -353,12 +353,29 @@ static int exec_set(void *arg, int argc, const char **argv) {
 }
 
 static int exec_send(void *arg, int argc, const char **argv) {
-  if (argc == 3) {
+  if (argc >= 3) {
     unsigned int address = 0;
     unsigned int opcode = 0;
     if (sscanf(argv[1], "%x", &address) == 1 && address <= 0x0f
         && sscanf(argv[2], "%x", &opcode) == 1 && opcode <= UINT8_MAX) {
-      if (cec_send_msg((uint8_t)address, (uint8_t)opcode)) {
+      cec_message_t msg = {0};
+      msg.header = HEADER0(cec_get_logical_address(), (uint8_t)address);
+      msg.opcode = (uint8_t)opcode;
+      msg.len = 2;  // header + opcode
+
+      // Parse optional operands (hex bytes)
+      for (int i = 3; i < argc && msg.len < CEC_FRAME_MAX_LEN; i++) {
+        unsigned int byte;
+        if (sscanf(argv[i], "%x", &byte) == 1 && byte <= 0xff) {
+          msg.operand[msg.len - 2] = (uint8_t)byte;
+          msg.len++;
+        } else {
+          cdc_printfln("Error parsing operand %d", i);
+          return -1;
+        }
+      }
+
+      if (cec_send_msg(&msg)) {
         return 0;
       }
       cdc_printfln("Send failed (queue full)");
@@ -373,7 +390,8 @@ static const tclie_cmd_t cmds[] = {
     {"debug", exec_debug, "Control debug output.", "debug {on|off}"},
     {"query", exec_query, "Query information.", "query {edid}"},
     {"save", exec_save, "Save configuration.", "save"},
-    {"send", exec_send, "Send a CEC opcode.", "send <addr> <opcode>"},
+    {"send", exec_send, "Send a CEC opcode.",
+     "send <addr> <opcode> [<operand>] [<operand>] [<operand>]"},
     {"set", exec_set, "Set configuration parameters.",
      "set {(config (edid_delay_ms|logical_address|physical_address <value>)|(device_type "
      "{playback|recording}))|(keymap ({kodi|mister}|(custom <cec> <hid>)))}"},


### PR DESCRIPTION
Hi,

I love the project, thanks for making it!
I just needed to allow for additional operands to make it perfect for my use-case.
In my case I needed switching active HDMI source via serial with command like `send f 82 14 00` 

The code is the first approximation that was viable for me. I'd be glad to change it to fit the project goals better.

cheers :)
