### PR TITLE
Support run-time config setting for OSD name (#93)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ set_source_files_properties(src/cec-frame.c PROPERTIES COMPILE_DEFINITIONS
 set_source_files_properties(src/usb-cdc.c PROPERTIES COMPILE_DEFINITIONS
   "PICO_CEC_VERSION=\"${PICO_CEC_VERSION}\"")
 
-set_source_files_properties(src/cec-task.c PROPERTIES COMPILE_DEFINITIONS
+set_source_files_properties(src/nvs.c PROPERTIES COMPILE_DEFINITIONS
   "CEC_OSD_NAME=\"${CEC_OSD_NAME}\"")
 
 # Undefine TinyUSB built-in OS, redefined in our tusb_config.h

--- a/include/cec-config.h
+++ b/include/cec-config.h
@@ -48,6 +48,9 @@ typedef struct {
   /** Keymap configuration. */
   cec_config_keymap_t keymap_type;
 
+  /** CEC OSD name. */
+  char osd_name[CEC_OSD_NAME_MAX_LEN + 1];
+
   /** User Control key mapping table. */
   command_t keymap[UINT8_MAX];
 } cec_config_t;

--- a/src/cec-config.c
+++ b/src/cec-config.c
@@ -107,6 +107,7 @@ void cec_config_set_default(cec_config_t *config) {
   config->physical_address = default_physical_addr;
   config->logical_address = default_logical_addr;
   config->device_type = default_device_type;
+  config->osd_name[0] = '\0';
 #if KEYMAP_DEFAULT_KODI
   config->keymap_type = CEC_CONFIG_KEYMAP_KODI;
 #elif KEYMAP_DEFAULT_MISTER

--- a/src/cec-task.c
+++ b/src/cec-task.c
@@ -131,8 +131,7 @@ static void system_audio_mode_status(uint8_t initiator,
 }
 
 static void set_osd_name(uint8_t initiator, uint8_t destination) {
-  const char *osd_name = CEC_OSD_NAME;
-  uint8_t name_len = strnlen(osd_name, CEC_OSD_NAME_MAX_LEN);
+  uint8_t name_len = strnlen(config.osd_name, CEC_OSD_NAME_MAX_LEN);
 
   cec_message_t message = {
       .header = HEADER0(initiator, destination),
@@ -140,7 +139,7 @@ static void set_osd_name(uint8_t initiator, uint8_t destination) {
       .len = 2 + name_len,
   };
 
-  memcpy(message.operand, osd_name, name_len);
+  memcpy(message.operand, config.osd_name, name_len);
 
   cec_frame_send(&message);
 }

--- a/src/nvs.c
+++ b/src/nvs.c
@@ -25,6 +25,7 @@ typedef struct __attribute__((packed)) {
  * CEC configuration block NVS representation (version 1)
  *
  * Structure is packed to ensure checksum correctness.
+ * Do not modify to ensure non-volatile storage compatibility.
  */
 typedef struct __attribute__((packed)) {
   /** DDC EDID delay in milliseconds. */
@@ -38,7 +39,33 @@ typedef struct __attribute__((packed)) {
 } cec_config_nvs_v1_t;
 
 /**
- * CEC configuration block NVS representation.
+ * CEC configuration block NVS representation (version 2)
+ *
+ * Structure is packed to ensure checksum correctness.
+ * Do not modify to ensure non-volatile storage compatibility.
+ */
+typedef struct __attribute__((packed)) {
+  /** DDC EDID delay in milliseconds. */
+  uint32_t edid_delay_ms;
+
+  /** CEC physical address. */
+  uint16_t physical_address;
+
+  /** CEC logical address (unused). */
+  uint8_t logical_address;
+
+  /** CEC device type (unused). */
+  uint8_t device_type;
+
+  /** Keymap. */
+  cec_config_keymap_t keymap_type;
+
+  /** User Control key mapping table. */
+  uint8_t keymap[UINT8_MAX];
+} cec_config_nvs_v2_t;
+
+/**
+ * CEC configuration block NVS representation (current, v3).
  *
  * Structure is packed to ensure checksum correctness.
  */
@@ -57,6 +84,9 @@ typedef struct __attribute__((packed)) {
 
   /** Keymap. */
   cec_config_keymap_t keymap_type;
+
+  /** CEC OSD name. */
+  char osd_name[CEC_OSD_NAME_MAX_LEN + 1];
 
   /** User Control key mapping table. */
   uint8_t keymap[UINT8_MAX];
@@ -88,7 +118,8 @@ extern uint32_t __CEC_NVS_LEN[];
 #define CEC_NVS_LEN ((uint32_t)(&__CEC_NVS_LEN))
 
 const uint8_t CEC_CONFIG_VERSION_01 = 0x01;
-const uint8_t CEC_CONFIG_VERSION = 0x02;
+const uint8_t CEC_CONFIG_VERSION_02 = 0x02;
+const uint8_t CEC_CONFIG_VERSION = 0x03;
 const size_t CEC_CONFIG_SIZE = sizeof(cec_config_t);
 
 static uint32_t nvs_get_flash_address(void) {
@@ -115,6 +146,28 @@ static bool migrate_v1(const pico_cec_nvs_t *nvs, cec_config_t *config) {
 }
 
 /**
+ * Migrate v2 config to current config.
+ */
+static bool migrate_v2(const pico_cec_nvs_t *nvs, cec_config_t *config) {
+  if (crc32((unsigned char *)&nvs->config, sizeof(cec_config_nvs_v2_t)) == nvs->config_crc) {
+    cec_config_nvs_v2_t *configv2 = (cec_config_nvs_v2_t *)&nvs->config;
+    // deserialise and migrate
+    config->edid_delay_ms = configv2->edid_delay_ms;
+    config->physical_address = configv2->physical_address;
+    config->logical_address = configv2->logical_address;
+    config->device_type = configv2->device_type;
+    config->keymap_type = configv2->keymap_type;
+    for (uint8_t n = 0; n < UINT8_MAX; n++) {
+      config->keymap[n].key = configv2->keymap[n];
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+/**
  * Load current config.
  */
 static bool load_config(pico_cec_nvs_t *nvs, cec_config_t *config) {
@@ -132,6 +185,7 @@ static bool load_config(pico_cec_nvs_t *nvs, cec_config_t *config) {
     for (uint8_t n = 0; n < UINT8_MAX; n++) {
       config->keymap[n].key = nvs->config.keymap[n];
     }
+    memcpy(config->osd_name, nvs->config.osd_name, sizeof(nvs->config.osd_name));
 
     return true;
   }
@@ -152,6 +206,8 @@ bool nvs_read_config(cec_config_t *config) {
   if (crc32((unsigned char *)&cec_nvs->header, sizeof(cec_nvs->header)) == cec_nvs->header_crc) {
     if (cec_nvs->header.version == CEC_CONFIG_VERSION_01) {
       success = migrate_v1(cec_nvs, config);
+    } else if (cec_nvs->header.version == CEC_CONFIG_VERSION_02) {
+      success = migrate_v2(cec_nvs, config);
     } else if (cec_nvs->header.version == CEC_CONFIG_VERSION) {
       success = load_config(cec_nvs, config);
     }
@@ -176,6 +232,12 @@ void nvs_load_config(cec_config_t *config) {
   }
 
   cec_config_complete(config);
+
+  // If empty, use default CEC OSD name.
+  if (config->osd_name[0] == '\0') {
+    strncpy(config->osd_name, CEC_OSD_NAME, CEC_OSD_NAME_MAX_LEN);
+    config->osd_name[CEC_OSD_NAME_MAX_LEN] = '\0';
+  }
 
   return;
 }
@@ -202,6 +264,8 @@ bool nvs_save_config(const cec_config_t *config) {
   for (unsigned int n = 0; n < UINT8_MAX; n++) {
     cec_nvs.config.keymap[n] = config->keymap[n].key;
   }
+
+  memcpy(cec_nvs.config.osd_name, config->osd_name, sizeof(cec_nvs.config.osd_name));
 
   cec_nvs.config_crc = crc32((unsigned char *)&cec_nvs.config, sizeof(cec_nvs.config));
 

--- a/src/usb-cdc.c
+++ b/src/usb-cdc.c
@@ -1,3 +1,4 @@
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 #include <tusb.h>
@@ -110,6 +111,10 @@ static void print_logical_address(uint8_t address) {
   cdc_printfln("%-17s: 0x%02x", "Logical address", address);
 }
 
+static void print_osd_name(const char *name) {
+  cdc_printfln("%-17s: %s", "OSD name", name);
+}
+
 static int show_config(cec_config_t *config) {
   // UBaseType_t uxHighWaterMark = uxTaskGetStackHighWaterMark(NULL);
   // cdc_printfln("StackHighWaterMark = %lu", uxHighWaterMark);
@@ -153,6 +158,8 @@ static int show_config(cec_config_t *config) {
       break;
   }
   cdc_printfln("%-17s: %s", "Keymap", keymap);
+
+  print_osd_name(config->osd_name);
 
   return 0;
 }
@@ -305,6 +312,22 @@ static int exec_set(void *arg, int argc, const char **argv) {
           cdc_printfln("Unknown device type \'%s\'", argv[3]);
           return -1;
         }
+      } else if (strcmp(argv[2], "osd_name") == 0) {
+        if (strlen(argv[3]) > CEC_OSD_NAME_MAX_LEN) {
+          cdc_printfln("OSD name too long (max %d characters)", CEC_OSD_NAME_MAX_LEN);
+          return -1;
+        }
+        for (size_t i = 0; argv[3][i] != '\0'; i++) {
+          if (!isprint((unsigned char)argv[3][i])) {
+            cdc_printfln("OSD name contains non-printable characters");
+            return -1;
+          }
+        }
+        size_t len = strlen(argv[3]);
+        memcpy(config.osd_name, argv[3], len);
+        config.osd_name[len] = '\0';
+        print_osd_name(config.osd_name);
+        return 0;
       }
     }
   } else if (argc >= 3) {
@@ -393,7 +416,7 @@ static const tclie_cmd_t cmds[] = {
     {"send", exec_send, "Send a CEC opcode.",
      "send <addr> <opcode> [<operand>] [<operand>] [<operand>]"},
     {"set", exec_set, "Set configuration parameters.",
-     "set {(config (edid_delay_ms|logical_address|physical_address <value>)|(device_type "
+     "set {(config (edid_delay_ms|logical_address|physical_address|osd_name <value>)|(device_type "
      "{playback|recording}))|(keymap ({kodi|mister}|(custom <cec> <hid>)))}"},
     {"show", exec_show, "Show information.",
      "show {cec|config|keymap|nvs|(stats {cec|cpu|tasks})|version}"},


### PR DESCRIPTION
OSD name is now a configuration setting.
Added:
- CLI support for set/show
- NVS storage for persistence

Defaults to 'Pico-CEC' if not configured.